### PR TITLE
feat: 예약 시스템 기본 시간 및 추가 요금 정보 업데이트 

### DIFF
--- a/apps/src/app/(user)/(standalone)/reservation/form/page.tsx
+++ b/apps/src/app/(user)/(standalone)/reservation/form/page.tsx
@@ -109,7 +109,7 @@ const ReservationForm = ({
           <h2 className="text-lg font-bold">{initialCategory.categoryName}</h2>
           <p className="text-sm text-gray-600">
             기본 금액 {initialCategory.categoryPrice.toLocaleString()}원 
-            (기본 시간 {initialCategory.categoryTime}시간)
+            • 추가시간 시간당 20,000원
           </p>
         </div>
 

--- a/apps/src/app/(user)/(standalone)/reservation/page.tsx
+++ b/apps/src/app/(user)/(standalone)/reservation/page.tsx
@@ -123,7 +123,8 @@ function ReservationPage() {
             key={category.categoryId}
             categoryId={category.categoryId}
             title={category.categoryName}
-            description={[`시간당 ${category.categoryPrice.toLocaleString()}원 (기본 ${category.categoryTime}시간)`]}
+            description={[`기본 ${category.categoryPrice.toLocaleString()}원 (2시간)`,
+              `• 추가시간당 20,000원`]}
             className="h-auto"
           />
         ))}

--- a/apps/src/features/reservation/hooks/useReservationForm.ts
+++ b/apps/src/features/reservation/hooks/useReservationForm.ts
@@ -18,7 +18,7 @@ export const useReservationForm = ({ initialCategory, initialOptions, addressId 
   const [warningMessage, setWarningMessage] = useState('');
   const [isTimeModalOpen, setIsTimeModalOpen] = useState(false);
   const [isVisitTimeModalOpen, setIsVisitTimeModalOpen] = useState(false);
-  const [selectedHours, setSelectedHours] = useState(initialCategory.categoryTime);
+  const [selectedHours, setSelectedHours] = useState(2); // 기본 시간 2시간 고정
   const [selectedVisitTime, setSelectedVisitTime] = useState<string | null>(null);
   const [selectedCategoryOptions, setSelectedCategoryOptions] = useState<number[]>([]);
   const [memo, setMemo] = useState('');
@@ -104,7 +104,12 @@ export const useReservationForm = ({ initialCategory, initialOptions, addressId 
     return total + (option?.coTime || 0);
   }, 0);
 
-  const baseServicePrice = calculatePrice(selectedHours, initialCategory.categoryPrice, initialCategory.categoryPrice, initialCategory.categoryTime);
+  // 백엔드 로직과 동일하게 수정
+  // 총가격 = categoryPrice + (선택시간 - 2) * 20000 + 옵션가격
+  const HOURLY_AMOUNT = 20000; // 시간당 가격 고정
+  const BASE_DURATION = 2; // 기본 시간 고정
+  const additionalHours = Math.max(0, selectedHours - BASE_DURATION);
+  const baseServicePrice = initialCategory.categoryPrice + (additionalHours * HOURLY_AMOUNT);
   const totalPrice = baseServicePrice + totalOptionsPrice;
   const totalDuration = selectedHours * 60 + totalOptionsTime;
 
@@ -114,7 +119,7 @@ export const useReservationForm = ({ initialCategory, initialOptions, addressId 
   const handleTimeChange = (increment: boolean) => {
     setSelectedHours(prev => {
       const newHours = increment ? prev + 1 : prev - 1;
-      if (newHours < initialCategory.categoryTime || newHours > 12) return prev;
+      if (newHours < BASE_DURATION || newHours > 12) return prev;
       
       if (recommendedTime && newHours < recommendedTime.time) {
         setShowTimeWarning(true);
@@ -163,7 +168,7 @@ export const useReservationForm = ({ initialCategory, initialOptions, addressId 
       reservationDuration: selectedHours,
       reservationMemo: memo,
       reservationAmount: totalPrice,
-      additionalDuration: selectedHours - initialCategory.categoryTime,
+      additionalDuration: selectedHours - BASE_DURATION,
       optionIds: selectedCategoryOptions,
     };
 
@@ -213,15 +218,15 @@ export const useReservationForm = ({ initialCategory, initialOptions, addressId 
     isOptionsLoading: false,
     optionsError: null,
     
-    standardHours: initialCategory.categoryTime,
+    standardHours: BASE_DURATION, // 기본 시간 2시간 고정
     basePrice: initialCategory.categoryPrice,
-    pricePerHour: initialCategory.categoryPrice,
+    pricePerHour: HOURLY_AMOUNT, // 시간당 가격 20,000원 고정
     
     totalPrice: totalPrice,
     
     handleTimeChange,
     handleNext,
-    handleResetTime: () => setSelectedHours(initialCategory.categoryTime),
+    handleResetTime: () => setSelectedHours(BASE_DURATION),
     visitTimeSlots,
     isSubmitting,
     isLoading,

--- a/apps/src/features/reservation/ui/TimePickerModal.tsx
+++ b/apps/src/features/reservation/ui/TimePickerModal.tsx
@@ -98,11 +98,11 @@ export const TimePickerModal = ({
                   onClick={() => onTimeChange(false)}
                   className={`w-12 h-12 rounded-full flex items-center justify-center transition-all
                     ${
-                      selectedHours <= standardHours
+                      selectedHours <= 2
                         ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
                         : 'bg-white border-2 border-primary-500 text-primary-500 active:bg-white'
                     }`}
-                  disabled={selectedHours <= standardHours}
+                  disabled={selectedHours <= 2}
                 >
                   <svg 
                     width="16" 
@@ -124,7 +124,7 @@ export const TimePickerModal = ({
                     {selectedHours}시간
                   </p>
                   <p className="text-xs text-gray-500 mt-2">
-                    최소 {standardHours}시간, 
+                    최소 2시간, 
                     최대 {12}시간
                   </p>
                 </div>
@@ -160,7 +160,7 @@ export const TimePickerModal = ({
                 <div className="flex flex-col gap-2 mb-4">
                   <div className="flex justify-between items-center">
                     <p className="text-sm text-gray-600">
-                      기본 요금 ({standardHours}시간)
+                      기본 요금 (2시간)
                     </p>
                     <p className="text-base font-medium text-gray-800">
                       {basePrice.toLocaleString()}원
@@ -179,12 +179,7 @@ export const TimePickerModal = ({
                       총 서비스 시간
                     </span>
                     <span className="text-xl font-bold text-gray-800">
-                      {calculatePrice(
-                        selectedHours,
-                        basePrice,
-                        pricePerHour,
-                        standardHours,
-                      ).toLocaleString()}
+                      {(basePrice + Math.max(0, selectedHours - standardHours) * pricePerHour).toLocaleString()}
                       원
                     </span>
                   </div>


### PR DESCRIPTION
- 예약 페이지 및 폼에서 기본 시간을 2시간으로 고정하고, 추가 시간당 요금을 20,000원으로 설정
- 관련 UI에서 기본 요금 및 추가 요금 정보를 명확히 표시하여 사용자 이해도 향상
- 예약 폼의 상태 관리 로직을 수정하여 기본 시간에 맞춰 동작하도록 개선