### PR TITLE
매칭 알고리즘 연동

### DIFF
--- a/apps/src/app/(user)/(standalone)/matching/MatchingPageClient.tsx
+++ b/apps/src/app/(user)/(standalone)/matching/MatchingPageClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { MatchingHeader, ManagerList, BottomSection } from '@/widgets/manager'
 import { useManagerSelection } from '@/features/manager-selection'
+import { getRecommendedManagers, type MatchingRequestDto } from '@/entities/matching'
 import type { Manager } from '@/widgets/manager/model/manager'
 
 // 매니저 매칭 알고리즘 함수 (추후 확장 가능)
@@ -30,47 +31,32 @@ export default function MatchingPageClient() {
 
         const reservationInfo = JSON.parse(reservationInfoStr)
 
-        // 매니저 목록 가져오기
-        const response = await fetch(
-          'https://api.antmen.site:9091/api/v1/matchings',
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Accept: 'application/json',
-            },
-            body: JSON.stringify({
-              reservationDate: reservationInfo.reservationDate,
-              reservationTime: reservationInfo.reservationTime,
-              reservationDuration: reservationInfo.reservationDuration,
-              location: {
-                district: reservationInfo.addressId,
-              },
-            }),
-          },
-        )
-
-        if (!response.ok) {
-          throw new Error(`매니저 조회 실패: ${response.status}`)
+        // 매니저 목록 가져오기 - 알고리즘 API 함수 사용
+        const matchingRequest: MatchingRequestDto = {
+          reservationDate: reservationInfo.reservationDate,
+          reservationTime: reservationInfo.reservationTime,
+          reservationDuration: reservationInfo.reservationDuration,
+          addressId: reservationInfo.addressId,
         }
 
-        const data = await response.json()
+        const data = await getRecommendedManagers(
+          matchingRequest,
+          true,        // useDistanceFilter
+          'distance'   // sortType
+        )
 
-        // 데이터 구조 변환
+        // 데이터 구조 변환 - MatchingManagerListResponseDto에서 Manager로 변환
         const formattedManagers: Manager[] = Array.isArray(data)
           ? data.map((manager) => ({
               id: manager.managerId?.toString() || '',
               name: manager.managerName || '',
               gender: manager.managerGender || '미지정',
               age: manager.managerAge || 0,
-              rating: manager.rating || 0,
-              description:
-                manager.description || '성실하고 친절한 서비스를 제공합니다.',
-              profileImage: manager.managerName ? manager.managerName[0] : '매',
-              reviewCount: manager.reviewCount || 0,
-              introduction:
-                manager.introduction ||
-                '안녕하세요! 성실하고 친절한 매니저입니다.',
+              rating: manager.managerRating || 0,
+              description: manager.managerComment || '성실하고 친절한 서비스를 제공합니다.',
+              profileImage: manager.managerImage || (manager.managerName ? manager.managerName[0] : '매'),
+              reviewCount: 0, // API 응답에 없음, 기본값 사용
+              introduction: manager.managerComment || '안녕하세요! 성실하고 친절한 매니저입니다.',
               characteristics: [
                 { id: '1', label: '친절해요', type: 'kind' as const },
                 { id: '2', label: '시간 엄수', type: 'punctual' as const },

--- a/apps/src/app/(user)/(standalone)/matching/MatchingPageClient.tsx
+++ b/apps/src/app/(user)/(standalone)/matching/MatchingPageClient.tsx
@@ -8,7 +8,6 @@ import type { Manager } from '@/widgets/manager/model/manager'
 
 // 매니저 매칭 알고리즘 함수 (추후 확장 가능)
 function getMatchedManagers(managers: Manager[], count: number = 5): Manager[] {
-  // TODO: 추후 알고리즘 적용 (예: 적합도, 거리, 평점 등)
   
   // return managers.slice(0, count)
   return managers // 임시: 전체 매니저 반환 (테스트용)

--- a/apps/src/entities/matching/api/matchingAPi.ts
+++ b/apps/src/entities/matching/api/matchingAPi.ts
@@ -8,8 +8,8 @@ import {
   SortType,
 } from '../model/types'
 
-const BASE_URL = 'http://localhost:9092/v1/manager'
-const MATCHING_API_URL = 'http://localhost:9091/api/v1/matchings'
+const BASE_URL = 'https://api.antmen.site:9092/v1/manager'
+const MATCHING_API_URL = 'https://api.antmen.site:9091/api/v1/matchings'
 
 class ApiError extends Error {
   constructor(
@@ -116,7 +116,7 @@ export const getRecommendedManagers = async (
     })
     
     const response = await fetch(
-      `${MATCHING_API_URL}/matching?${queryParams}`,
+      `${MATCHING_API_URL}?${queryParams}`,
       {
         method: 'POST',
         headers: {

--- a/apps/src/entities/matching/api/matchingAPi.ts
+++ b/apps/src/entities/matching/api/matchingAPi.ts
@@ -3,10 +3,13 @@ import {
   ReservationHistoryDto,
   MatchingResponseRequestDto,
   PaginatedMatchingResponse,
+  MatchingRequestDto,
+  MatchingManagerListResponseDto,
+  SortType,
 } from '../model/types'
 
-const BASE_URL = 'https://api.antmen.site:9092/v1/manager'
-const MATCHING_API_URL = 'https://api.antmen.site:9091/api/v1/matchings'
+const BASE_URL = 'http://localhost:9092/v1/manager'
+const MATCHING_API_URL = 'http://localhost:9091/api/v1/matchings'
 
 class ApiError extends Error {
   constructor(
@@ -93,4 +96,62 @@ export const respondToMatching = async (
     )
   }
 }
-// 수요자 매칭 응답
+
+/**
+ * 추천 매니저 리스트 조회 API
+ * @param request - 예약 요청 정보
+ * @param useDistanceFilter - 거리 필터링 여부
+ * @param sortType - 정렬 기준 ("distance" | "recent")
+ * @returns Promise<MatchingManagerListResponseDto[]>
+ */
+export const getRecommendedManagers = async (
+  request: MatchingRequestDto,
+  useDistanceFilter: boolean = true,
+  sortType: SortType = 'distance'
+): Promise<MatchingManagerListResponseDto[]> => {
+  try {
+    const queryParams = new URLSearchParams({
+      useDistanceFilter: useDistanceFilter.toString(),
+      sortType: sortType,
+    })
+    
+    const response = await fetch(
+      `${MATCHING_API_URL}/matching?${queryParams}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(request),
+      }
+    )
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => null)
+      console.error('Get Recommended Managers Error:', {
+        status: response.status,
+        statusText: response.statusText,
+        errorData,
+      })
+      throw new ApiError(
+        errorData?.errorMessage || '추천 매니저 조회에 실패했습니다.',
+        response.status,
+        response.statusText,
+      )
+    }
+
+    const data: MatchingManagerListResponseDto[] = await response.json()
+    return data
+
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error
+    }
+    console.error('Get recommended managers error:', error)
+    throw new ApiError(
+      '서버와 통신하는데 실패했습니다',
+      500,
+      'Internal Server Error',
+    )
+  }
+}

--- a/apps/src/entities/matching/index.ts
+++ b/apps/src/entities/matching/index.ts
@@ -9,4 +9,15 @@ export type {
   MatchingDto,
   PageableResponse,
   PaginatedMatchingResponse,
+  MatchingRequestDto,
+  MatchingManagerListResponseDto,
+  SortType,
 } from './model/types'
+
+export {
+  getMatchingRequests,
+  acceptMatchingRequest,
+  rejectMatchingRequest,
+  respondToMatching,
+  getRecommendedManagers,
+} from './api/matchingAPi'

--- a/apps/src/entities/matching/model/types.ts
+++ b/apps/src/entities/matching/model/types.ts
@@ -124,4 +124,4 @@ export interface MatchingManagerListResponseDto {
   managerImage: string
 }
 
-export type SortType = 'distance' | 'recent'
+export type SortType = 'distance' | 'recent' // todo: 추후 리뷰순 추가 예정

--- a/apps/src/entities/matching/model/types.ts
+++ b/apps/src/entities/matching/model/types.ts
@@ -105,3 +105,23 @@ export interface PageableResponse<T> {
 }
 
 export type PaginatedMatchingResponse = PageableResponse<ReservationHistoryDto>
+
+// 추천 매니저 리스트 조회 API 관련 타입들
+export interface MatchingRequestDto {
+  reservationDate: string        // 예약 날짜 (YYYY-MM-DD)
+  reservationTime: string        // 예약 시작 시간 (HH:mm)
+  reservationDuration: number    // 예약 소요 시간 (시간 단위)
+  addressId: number              // 고객 주소 ID
+}
+
+export interface MatchingManagerListResponseDto {
+  managerId: number
+  managerName: string
+  managerGender: string
+  managerAge: number
+  managerComment: string
+  managerRating: number
+  managerImage: string
+}
+
+export type SortType = 'distance' | 'recent'


### PR DESCRIPTION
백엔드 api 연동했습니다

매칭 매니저 리스트 출력 : 알고리즘에 따라서 상위 5명만 -> 우선 전체 다 부르는 중, 추후 5명 페이징처리
우선 매니저 스케줄부터 확인해서 가능한 시간인지 비교 ✅
거리비교해서 10km이내 매니저 반환✅
현재는 최신순, 가까운순으로 sort 정렬✅
추후 리뷰 연동