### PR TITLE
feat: 관리자 환불 통계 기능 구현

### DIFF
--- a/admin/src/api/adminRefunds.ts
+++ b/admin/src/api/adminRefunds.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { AdminRefundResponseDto, AdminRefundStatisticsResponseDto, AdminRefundReasonDto, AdminRefundCustomerTopDto } from './types';
+import { AdminRefundResponseDto, AdminRefundStatisticsResponseDto, AdminRefundReasonDto, AdminRefundCustomerTopDto, AdminRefundManagerTopDto } from './types';
 import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
 
 const API_BASE_URL = 'http://localhost:9093/api/v1';
@@ -104,6 +104,19 @@ export const adminRefundsService = {
     getRefundCustomerTop: async (): Promise<AdminRefundCustomerTopDto[]> => {
         try {
             const response = await refundsApi.get('/admin/statistics/refunds/customers/top');
+            return response.data;
+        } catch (error: any) {
+            if (error.response?.status === 401) {
+                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
+            }
+            throw error;
+        }
+    },
+
+    // 매니저별 환불금액 TOP3 조회
+    getRefundManagerTop: async (): Promise<AdminRefundManagerTopDto[]> => {
+        try {
+            const response = await refundsApi.get('/admin/statistics/refunds/managers/top');
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {

--- a/admin/src/api/adminRefunds.ts
+++ b/admin/src/api/adminRefunds.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { AdminRefundResponseDto, AdminRefundStatisticsResponseDto, AdminRefundReasonDto } from './types';
+import { AdminRefundResponseDto, AdminRefundStatisticsResponseDto, AdminRefundReasonDto, AdminRefundCustomerTopDto } from './types';
 import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
 
 const API_BASE_URL = 'http://localhost:9093/api/v1';
@@ -91,6 +91,19 @@ export const adminRefundsService = {
     getRefundReasons: async (): Promise<AdminRefundReasonDto[]> => {
         try {
             const response = await refundsApi.get('/admin/statistics/refunds/reasons');
+            return response.data;
+        } catch (error: any) {
+            if (error.response?.status === 401) {
+                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
+            }
+            throw error;
+        }
+    },
+    
+    // 사용자별 환불률 TOP3 조회
+    getRefundCustomerTop: async (): Promise<AdminRefundCustomerTopDto[]> => {
+        try {
+            const response = await refundsApi.get('/admin/statistics/refunds/customers/top');
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {

--- a/admin/src/api/adminRefunds.ts
+++ b/admin/src/api/adminRefunds.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { AdminRefundResponseDto, AdminRefundStatisticsResponseDto, AdminRefundReasonDto, AdminRefundCustomerTopDto, AdminRefundManagerTopDto } from './types';
 import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
 
-const API_BASE_URL = 'http://localhost:9093/api/v1';
+const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
 
 // 환불 API 인스턴스
 const refundsApi = axios.create({

--- a/admin/src/api/adminReview.ts
+++ b/admin/src/api/adminReview.ts
@@ -1,0 +1,58 @@
+import axios from 'axios';
+import { AdminReviewStatisticsResponseDto } from './types';
+import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
+
+const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
+
+// 만족도 통계 API 인스턴스
+const reviewApi = axios.create({
+    baseURL: API_BASE_URL,
+    headers: {
+        'Content-Type': 'application/json',
+    },
+});
+
+// 요청 인터셉터: 토큰 자동 추가
+reviewApi.interceptors.request.use(
+    (config) => {
+        let token = getCookie(ADMIN_TOKEN_COOKIE);
+        if (!token) {
+            token = localStorage.getItem('adminToken');
+        }
+        if (token) {
+            config.headers.Authorization = `Bearer ${token}`;
+        }
+        return config;
+    },
+    (error) => Promise.reject(error)
+);
+
+// 응답 인터셉터: 401 에러 시 로그인 페이지로 리다이렉트
+reviewApi.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        if (error.response?.status === 401) {
+            alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
+            localStorage.removeItem('adminUser');
+            localStorage.removeItem('adminToken');
+            document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+            window.location.href = '/admin/login';
+        }
+        return Promise.reject(error);
+    }
+);
+
+export const adminReviewService = {
+    // 만족도 통계 조회
+    getReviewStatistics: async (topN: number = 3): Promise<AdminReviewStatisticsResponseDto> => {
+        try {
+            const response = await reviewApi.get(`/admin/statistics/reviews/?topN=${topN}`);
+            return response.data;
+        } catch (error: any) {
+            if (error.response?.status === 401) {
+                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
+            }
+            throw error;
+        }
+    },
+};

--- a/admin/src/api/types.ts
+++ b/admin/src/api/types.ts
@@ -148,6 +148,14 @@ export interface AdminRefundReasonDto {
     count: number;                      // 건수
 }
 
+// 사용자별 환불률 TOP3 응답 타입
+export interface AdminRefundCustomerTopDto {
+    customerId: number;                 // 고객 ID
+    customerName: string;               // 고객명
+    refundCount: number;                // 환불 건수
+    totalRefundAmount: number;          // 총 환불 금액
+}
+
 // 정산 관련 타입
 export interface AdminCalculationItemDto {
     calculationId: number;              // 정산 ID

--- a/admin/src/api/types.ts
+++ b/admin/src/api/types.ts
@@ -235,3 +235,20 @@ export interface CategoryOptionRequestDto {
     coPrice: number;                    // 추가 가격
     coTime: number;                     // 추가 시간 (분)
 }
+
+// 만족도 통계 응답 타입
+export interface AdminReviewStatisticsResponseDto {
+    totalReviewCount: number;
+    avgReviewSatisfaction: number;
+    avgCustomerReviewSatisfaction: number;
+    avgManagerReviewSatisfaction: number;
+    topCustomerList: AdminReviewUserStatDto[];
+    topManagerList: AdminReviewUserStatDto[];
+}
+
+export interface AdminReviewUserStatDto {
+    userId: number;
+    userName: string;
+    avgReview: number;
+    totalReviewCount: number;
+}

--- a/admin/src/api/types.ts
+++ b/admin/src/api/types.ts
@@ -156,6 +156,14 @@ export interface AdminRefundCustomerTopDto {
     totalRefundAmount: number;          // 총 환불 금액
 }
 
+// 매니저별 환불금액 TOP3 응답 타입
+export interface AdminRefundManagerTopDto {
+    managerId: number;                  // 매니저 ID
+    managerName: string;                // 매니저명
+    refundCount: number;                // 환불 건수
+    totalRefundAmount: number;          // 총 환불 금액
+}
+
 // 정산 관련 타입
 export interface AdminCalculationItemDto {
     calculationId: number;              // 정산 ID

--- a/admin/src/pages/admin/StatRefund.tsx
+++ b/admin/src/pages/admin/StatRefund.tsx
@@ -1,15 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../components/ui/card';
 import { adminRefundsService } from '../../api/adminRefunds';
-import { AdminRefundStatisticsResponseDto, AdminRefundReasonDto } from '../../api/types';
-
-// 사용자별 환불률 - 추후 API 연동 예정
-const userRefunds = [
-  { name: '홍길동', refunds: 3, total: 20, rate: 15 },
-  { name: '김철수', refunds: 2, total: 18, rate: 11 },
-  { name: '이영희', refunds: 1, total: 25, rate: 4 },
-  { name: '박민수', refunds: 1, total: 12, rate: 8 },
-];
+import { AdminRefundStatisticsResponseDto, AdminRefundReasonDto, AdminRefundCustomerTopDto } from '../../api/types';
 
 // 매니저별 환불률 - 추후 API 연동 예정
 const managerRefunds = [
@@ -29,6 +21,7 @@ const predefinedReasons = [
 export const StatRefund: React.FC = () => {
   const [refundStatistics, setRefundStatistics] = useState<AdminRefundStatisticsResponseDto | null>(null);
   const [refundReasons, setRefundReasons] = useState<AdminRefundReasonDto[]>([]);
+  const [customerTop, setCustomerTop] = useState<AdminRefundCustomerTopDto[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showOtherDetails, setShowOtherDetails] = useState(false);
@@ -37,15 +30,15 @@ export const StatRefund: React.FC = () => {
     const fetchRefundData = async () => {
       try {
         setLoading(true);
-        
-        // 통계와 사유 분포를 병렬로 가져오기
-        const [statisticsData, reasonsData] = await Promise.all([
+        // 통계, 사유 분포, 사용자별 환불률 top3를 병렬로 가져오기
+        const [statisticsData, reasonsData, customerTopData] = await Promise.all([
           adminRefundsService.getRefundStatistics(),
-          adminRefundsService.getRefundReasons()
+          adminRefundsService.getRefundReasons(),
+          adminRefundsService.getRefundCustomerTop()
         ]);
-        
         setRefundStatistics(statisticsData);
         setRefundReasons(reasonsData);
+        setCustomerTop(customerTopData.slice(0, 3)); // 혹시 3개 이상 와도 top3만
         setError(null);
       } catch (err: any) {
         console.error('환불 데이터 조회 실패:', err);
@@ -54,7 +47,6 @@ export const StatRefund: React.FC = () => {
         setLoading(false);
       }
     };
-
     fetchRefundData();
   }, []);
 
@@ -227,29 +219,29 @@ export const StatRefund: React.FC = () => {
         </CardContent>
       </Card>
 
-      {/* 사용자별 환불률 */}
+      {/* 고객별 환불금액 TOP3 */}
       <Card>
         <CardHeader>
-          <CardTitle>사용자별 환불률 TOP4</CardTitle>
-          <CardDescription>최근 30일 기준 (추후 API 연동 예정)</CardDescription>
+          <CardTitle>고객별 환불금액 TOP3</CardTitle>
+          <CardDescription>누적 기준, 환불금액 상위 3명</CardDescription>
         </CardHeader>
         <CardContent>
           <table className="min-w-full text-center text-sm">
             <thead>
               <tr className="bg-gray-50">
+                <th className="p-2">고객ID</th>
                 <th className="p-2">이름</th>
                 <th className="p-2">환불 건수</th>
-                <th className="p-2">총 이용 건수</th>
-                <th className="p-2">환불률(%)</th>
+                <th className="p-2">총 환불 금액</th>
               </tr>
             </thead>
             <tbody>
-              {userRefunds.map((u) => (
-                <tr key={u.name} className="border-b">
-                  <td className="p-2 font-medium">{u.name}</td>
-                  <td className="p-2">{u.refunds}</td>
-                  <td className="p-2">{u.total}</td>
-                  <td className="p-2 text-blue-600 font-bold">{u.rate}%</td>
+              {customerTop.map((u) => (
+                <tr key={u.customerId} className="border-b">
+                  <td className="p-2">{u.customerId}</td>
+                  <td className="p-2 font-semibold">{u.customerName}</td>
+                  <td className="p-2 text-blue-600 font-bold">{u.refundCount}</td>
+                  <td className="p-2">₩{u.totalRefundAmount.toLocaleString()}</td>
                 </tr>
               ))}
             </tbody>

--- a/admin/src/pages/admin/StatRefund.tsx
+++ b/admin/src/pages/admin/StatRefund.tsx
@@ -1,14 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../components/ui/card';
 import { adminRefundsService } from '../../api/adminRefunds';
-import { AdminRefundStatisticsResponseDto, AdminRefundReasonDto, AdminRefundCustomerTopDto } from '../../api/types';
-
-// 매니저별 환불률 - 추후 API 연동 예정
-const managerRefunds = [
-  { name: '김매니저', refunds: 5, total: 40, rate: 12 },
-  { name: '이매니저', refunds: 2, total: 35, rate: 6 },
-  { name: '박매니저', refunds: 1, total: 30, rate: 3 },
-];
+import { AdminRefundStatisticsResponseDto, AdminRefundReasonDto, AdminRefundCustomerTopDto, AdminRefundManagerTopDto } from '../../api/types';
 
 // 주요 환불 사유 정의
 const predefinedReasons = [
@@ -22,6 +15,7 @@ export const StatRefund: React.FC = () => {
   const [refundStatistics, setRefundStatistics] = useState<AdminRefundStatisticsResponseDto | null>(null);
   const [refundReasons, setRefundReasons] = useState<AdminRefundReasonDto[]>([]);
   const [customerTop, setCustomerTop] = useState<AdminRefundCustomerTopDto[]>([]);
+  const [managerTop, setManagerTop] = useState<AdminRefundManagerTopDto[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showOtherDetails, setShowOtherDetails] = useState(false);
@@ -30,15 +24,17 @@ export const StatRefund: React.FC = () => {
     const fetchRefundData = async () => {
       try {
         setLoading(true);
-        // 통계, 사유 분포, 사용자별 환불률 top3를 병렬로 가져오기
-        const [statisticsData, reasonsData, customerTopData] = await Promise.all([
+        // 통계, 사유 분포, 고객/매니저별 환불금액 top3를 병렬로 가져오기
+        const [statisticsData, reasonsData, customerTopData, managerTopData] = await Promise.all([
           adminRefundsService.getRefundStatistics(),
           adminRefundsService.getRefundReasons(),
-          adminRefundsService.getRefundCustomerTop()
+          adminRefundsService.getRefundCustomerTop(),
+          adminRefundsService.getRefundManagerTop()
         ]);
         setRefundStatistics(statisticsData);
         setRefundReasons(reasonsData);
-        setCustomerTop(customerTopData.slice(0, 3)); // 혹시 3개 이상 와도 top3만
+        setCustomerTop(customerTopData.slice(0, 3));
+        setManagerTop(managerTopData.slice(0, 3));
         setError(null);
       } catch (err: any) {
         console.error('환불 데이터 조회 실패:', err);
@@ -249,29 +245,29 @@ export const StatRefund: React.FC = () => {
         </CardContent>
       </Card>
 
-      {/* 매니저별 환불률 */}
+      {/* 매니저별 환불금액 TOP3 */}
       <Card>
         <CardHeader>
-          <CardTitle>매니저별 환불률 TOP3</CardTitle>
-          <CardDescription>최근 30일 기준 (추후 API 연동 예정)</CardDescription>
+          <CardTitle>매니저별 환불금액 TOP3</CardTitle>
+          <CardDescription>누적 기준, 환불금액 상위 3명</CardDescription>
         </CardHeader>
         <CardContent>
           <table className="min-w-full text-center text-sm">
             <thead>
               <tr className="bg-gray-50">
+                <th className="p-2">매니저ID</th>
                 <th className="p-2">이름</th>
                 <th className="p-2">환불 건수</th>
-                <th className="p-2">총 매칭 건수</th>
-                <th className="p-2">환불률(%)</th>
+                <th className="p-2">총 환불 금액</th>
               </tr>
             </thead>
             <tbody>
-              {managerRefunds.map((m) => (
-                <tr key={m.name} className="border-b">
-                  <td className="p-2 font-medium">{m.name}</td>
-                  <td className="p-2">{m.refunds}</td>
-                  <td className="p-2">{m.total}</td>
-                  <td className="p-2 text-blue-600 font-bold">{m.rate}%</td>
+              {managerTop.map((m) => (
+                <tr key={m.managerId} className="border-b">
+                  <td className="p-2">{m.managerId}</td>
+                  <td className="p-2 font-semibold">{m.managerName}</td>
+                  <td className="p-2 text-blue-600 font-bold">{m.refundCount}</td>
+                  <td className="p-2">₩{m.totalRefundAmount.toLocaleString()}</td>
                 </tr>
               ))}
             </tbody>

--- a/admin/src/pages/admin/StatSatisfaction.tsx
+++ b/admin/src/pages/admin/StatSatisfaction.tsx
@@ -1,154 +1,129 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../components/ui/card';
+import { adminReviewService } from '../../api/adminReview';
+import { AdminReviewStatisticsResponseDto } from '../../api/types';
 
-const stats = [
-  { label: '평균 만족도', value: '4.6 / 5', desc: '최근 100건 기준' },
-  { label: '5점 비율', value: '68%', desc: '최근 100건 기준' },
-  { label: '4점 비율', value: '22%', desc: '최근 100건 기준' },
-  { label: '3점 이하 비율', value: '10%', desc: '최근 100건 기준' },
-];
+export const StatSatisfaction: React.FC = () => {
+  const [data, setData] = useState<AdminReviewStatisticsResponseDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-const scoreDist = [
-  { score: 5, count: 68 },
-  { score: 4, count: 22 },
-  { score: 3, count: 7 },
-  { score: 2, count: 3 },
-  { score: 1, count: 0 },
-];
+  useEffect(() => {
+    setLoading(true);
+    adminReviewService.getReviewStatistics(3)
+      .then(setData)
+      .catch((e) => setError(e.message || '에러 발생'))
+      .finally(() => setLoading(false));
+  }, []);
 
-const recentReviews = [
-  { user: '홍길동', score: 5, comment: '매우 만족합니다!' },
-  { user: '김철수', score: 4, comment: '좋아요. 친절했어요.' },
-  { user: '이영희', score: 3, comment: '보통이에요.' },
-  { user: '박민수', score: 5, comment: '정말 최고입니다.' },
-];
+  if (loading) return <div>로딩 중...</div>;
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!data) return <div>데이터 없음</div>;
 
-const userSatisfaction = [
-  { name: '홍길동', avg: 4.8, count: 12 },
-  { name: '김철수', avg: 4.5, count: 10 },
-  { name: '이영희', avg: 4.2, count: 15 },
-];
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">만족도</h1>
+      <p className="text-gray-600 mb-4">평균 만족도, 사용자/매니저별 만족도를 확인하세요.</p>
 
-const managerSatisfaction = [
-  { name: '김매니저', avg: 4.9, count: 20 },
-  { name: '이매니저', avg: 4.7, count: 18 },
-  { name: '박매니저', avg: 4.6, count: 16 },
-];
-
-export const StatSatisfaction: React.FC = () => (
-  <div className="space-y-8">
-    <h1 className="text-2xl font-bold">만족도</h1>
-    <p className="text-gray-600 mb-4">평균 만족도, 평점 분포, 최근 평가, 사용자/매니저별 만족도를 확인하세요.</p>
-
-    {/* 주요 지표 카드 */}
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-      {stats.map((s) => (
-        <Card key={s.label}>
+      {/* 주요 지표 카드 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <Card>
           <CardHeader>
-            <CardTitle className="text-base font-medium">{s.label}</CardTitle>
-            <CardDescription className="text-xs">{s.desc}</CardDescription>
+            <CardTitle className="text-base font-medium">평균 만족도</CardTitle>
+            <CardDescription className="text-xs">전체 평균</CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-blue-700">{s.value}</div>
+            <div className="text-2xl font-bold text-blue-700">{data.avgReviewSatisfaction.toFixed(2)} / 5</div>
           </CardContent>
         </Card>
-      ))}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-medium">사용자 평균 만족도</CardTitle>
+            <CardDescription className="text-xs">전체</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-blue-700">{data.avgCustomerReviewSatisfaction.toFixed(2)} / 5</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-medium">매니저 평균 만족도</CardTitle>
+            <CardDescription className="text-xs">전체</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-blue-700">{data.avgManagerReviewSatisfaction.toFixed(2)} / 5</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-medium">총 평가 건수</CardTitle>
+            <CardDescription className="text-xs">누적</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-blue-700">{data.totalReviewCount}건</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 사용자별 만족도 TOP3 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>사용자별 평균 만족도 TOP3</CardTitle>
+          <CardDescription>최근 평가 기준</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <table className="min-w-full text-center text-sm">
+            <thead>
+              <tr className="bg-gray-50">
+                <th className="p-2">ID</th>
+                <th className="p-2">이름</th>
+                <th className="p-2">평균 평점</th>
+                <th className="p-2">평가 건수</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.topCustomerList.map((u) => (
+                <tr key={u.userId} className="border-b">
+                  <td className="p-2">{u.userId}</td>
+                  <td className="p-2 font-medium">{u.userName}</td>
+                  <td className="p-2 text-blue-700 font-bold">{u.avgReview}</td>
+                  <td className="p-2">{u.totalReviewCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      {/* 매니저별 만족도 TOP3 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>매니저별 평균 만족도 TOP3</CardTitle>
+          <CardDescription>최근 평가 기준</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <table className="min-w-full text-center text-sm">
+            <thead>
+              <tr className="bg-gray-50">
+                <th className="p-2">ID</th>
+                <th className="p-2">이름</th>
+                <th className="p-2">평균 평점</th>
+                <th className="p-2">평가 건수</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.topManagerList.map((m) => (
+                <tr key={m.userId} className="border-b">
+                  <td className="p-2">{m.userId}</td>
+                  <td className="p-2 font-medium">{m.userName}</td>
+                  <td className="p-2 text-blue-700 font-bold">{m.avgReview}</td>
+                  <td className="p-2">{m.totalReviewCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
     </div>
-
-    {/* 평점 분포 바 */}
-    <Card>
-      <CardHeader>
-        <CardTitle>평점 분포</CardTitle>
-        <CardDescription>최근 100건 기준</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-col gap-2">
-          {scoreDist.map((s) => (
-            <div key={s.score} className="flex items-center">
-              <div className="w-10 text-sm text-gray-700">{s.score}점</div>
-              <div className="flex-1 bg-gray-200 rounded h-3 mx-2">
-                <div className="bg-blue-500 h-3 rounded" style={{ width: `${s.count}%` }} />
-              </div>
-              <div className="w-10 text-right text-sm font-bold text-blue-700">{s.count}건</div>
-            </div>
-          ))}
-        </div>
-      </CardContent>
-    </Card>
-
-    {/* 최근 평가 */}
-    <Card>
-      <CardHeader>
-        <CardTitle>최근 평가</CardTitle>
-        <CardDescription>최신 4건</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <ul className="space-y-2">
-          {recentReviews.map((r, i) => (
-            <li key={i} className="flex items-center gap-4">
-              <span className="font-bold text-blue-700">{r.user}</span>
-              <span className="text-yellow-500">{'★'.repeat(r.score)}{'☆'.repeat(5 - r.score)}</span>
-              <span className="text-gray-700">{r.comment}</span>
-            </li>
-          ))}
-        </ul>
-      </CardContent>
-    </Card>
-
-    {/* 사용자별 만족도 */}
-    <Card>
-      <CardHeader>
-        <CardTitle>사용자별 평균 만족도 TOP3</CardTitle>
-        <CardDescription>최근 30일 기준</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <table className="min-w-full text-center text-sm">
-          <thead>
-            <tr className="bg-gray-50">
-              <th className="p-2">이름</th>
-              <th className="p-2">평균 평점</th>
-              <th className="p-2">평가 건수</th>
-            </tr>
-          </thead>
-          <tbody>
-            {userSatisfaction.map((u) => (
-              <tr key={u.name} className="border-b">
-                <td className="p-2 font-medium">{u.name}</td>
-                <td className="p-2 text-blue-700 font-bold">{u.avg}</td>
-                <td className="p-2">{u.count}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </CardContent>
-    </Card>
-
-    {/* 매니저별 만족도 */}
-    <Card>
-      <CardHeader>
-        <CardTitle>매니저별 평균 만족도 TOP3</CardTitle>
-        <CardDescription>최근 30일 기준</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <table className="min-w-full text-center text-sm">
-          <thead>
-            <tr className="bg-gray-50">
-              <th className="p-2">이름</th>
-              <th className="p-2">평균 평점</th>
-              <th className="p-2">평가 건수</th>
-            </tr>
-          </thead>
-          <tbody>
-            {managerSatisfaction.map((m) => (
-              <tr key={m.name} className="border-b">
-                <td className="p-2 font-medium">{m.name}</td>
-                <td className="p-2 text-blue-700 font-bold">{m.avg}</td>
-                <td className="p-2">{m.count}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </CardContent>
-    </Card>
-  </div>
-); 
+  );
+}; 


### PR DESCRIPTION
- #186 
- #187 이어서 올릴게용 :)

### ✅ 1. 환불 통계 기능

#### 🔹 전체 환불률 통계 API (\`GET /admin/refunds/summary\`)
- 전체 예약 대비 환불 비율 계산: \`refundRate = totalRefund / totalReservation * 100\`
- 승인 환불 수(\`APPROVED\`) 및 환불 금액 합계 포함
- 환불률은 소수점 둘째자리까지 반올림
- **DTO**: \`AdminRefundStatisticsSummaryDto\`

#### 🔹 환불 사유 통계 API (\`GET /admin/refunds/reasons\`)
- \`refundReason\` 기준 \`COUNT(*)\` 집계
- 프론트에서 기타 분류 가능하도록 전체 리스트 반환
- 정렬 기준: 발생 건수 내림차순
- **DTO**: \`AdminRefundReasonStatisticsDto\`

#### 🔹 사용자 환불 TOP API (\`GET /admin/refunds/customers/top\`)
- \`APPROVED\` 상태의 환불만 집계
- 사용자별 \`userId\`, \`userName\`, \`refundCount\`, \`totalRefundAmount\` 반환
- interface-based projection → DTO 변환 방식
- **DTO**: \`AdminCustomerRefundStatisticsDto\`

#### 🔹 매니저 환불 TOP API (\`GET /admin/refunds/managers/top\`)
- 사용자 통계와 동일 구조로 매니저 기준 통계 반환
- **DTO**: \`AdminManagerRefundStatisticsDto\`

---