### PR TITLE
[관리자] 관리자 통계 - 예약률 api 연동

### DIFF
--- a/admin/src/api/adminMatching.ts
+++ b/admin/src/api/adminMatching.ts
@@ -2,7 +2,7 @@ import { AdminMatchingStatisticsResponseDto } from './types';
 import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
 import axios from 'axios';
 
-const API_BASE_URL = 'http://localhost:9093/api/v1';
+const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
 
 // 매칭 통계 API 인스턴스
 const matchingApi = axios.create({

--- a/admin/src/api/adminMatching.ts
+++ b/admin/src/api/adminMatching.ts
@@ -1,0 +1,51 @@
+import { AdminMatchingStatisticsResponseDto } from './types';
+import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
+import axios from 'axios';
+
+const API_BASE_URL = 'http://localhost:9093/api/v1';
+
+// 매칭 통계 API 인스턴스
+const matchingApi = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// 요청 인터셉터: 토큰 자동 추가
+matchingApi.interceptors.request.use(
+  (config) => {
+    let token = getCookie(ADMIN_TOKEN_COOKIE);
+    if (!token) {
+      token = localStorage.getItem('adminToken');
+    }
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+// 응답 인터셉터: 401 에러 시 로그인 페이지로 리다이렉트
+matchingApi.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
+      localStorage.removeItem('adminUser');
+      localStorage.removeItem('adminToken');
+      document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+      window.location.href = '/admin/login';
+    }
+    return Promise.reject(error);
+  }
+);
+
+// 매칭 통계 대시보드 및 매니저 TOP 리스트 조회
+export async function fetchAdminMatchingStatistics(): Promise<AdminMatchingStatisticsResponseDto> {
+  const response = await matchingApi.get<AdminMatchingStatisticsResponseDto>(
+    '/admin/statistics/matchings'
+  );
+  return response.data;
+}

--- a/admin/src/api/adminReservation.ts
+++ b/admin/src/api/adminReservation.ts
@@ -1,0 +1,62 @@
+import axios from 'axios';
+import { AdminReservationStatisticsResponseDto } from './types';
+import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
+
+const API_BASE_URL = 'http://localhost:9093/api/v1';
+
+// 예약 API 인스턴스
+const reservationApi = axios.create({
+    baseURL: API_BASE_URL,
+    headers: {
+        'Content-Type': 'application/json',
+    },
+});
+
+// 요청 인터셉터: 토큰 자동 추가
+reservationApi.interceptors.request.use(
+    (config) => {
+        let token = getCookie(ADMIN_TOKEN_COOKIE);
+        if (!token) {
+            token = localStorage.getItem('adminToken');
+        }
+        if (token) {
+            config.headers.Authorization = `Bearer ${token}`;
+        }
+        return config;
+    },
+    (error) => {
+        return Promise.reject(error);
+    }
+);
+
+// 응답 인터셉터: 401 에러 시 로그인 페이지로 리다이렉트
+reservationApi.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        if (error.response?.status === 401) {
+            alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
+            localStorage.removeItem('adminUser');
+            localStorage.removeItem('adminToken');
+            document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+            window.location.href = '/admin/login';
+        }
+        return Promise.reject(error);
+    }
+);
+
+export const adminReservationService = {
+    // 관리자 예약 통계 조회
+    getReservationStatistics: async (recentDays: number = 7): Promise<AdminReservationStatisticsResponseDto> => {
+        try {
+            const response = await reservationApi.get(`/admin/statistics/reservations`, {
+                params: { recentDays },
+            });
+            return response.data;
+        } catch (error: any) {
+            if (error.response?.status === 401) {
+                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
+            }
+            throw error;
+        }
+    },
+};

--- a/admin/src/api/adminReservation.ts
+++ b/admin/src/api/adminReservation.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { AdminReservationStatisticsResponseDto } from './types';
 import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
 
-const API_BASE_URL = 'http://localhost:9093/api/v1';
+const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
 
 // 예약 API 인스턴스
 const reservationApi = axios.create({

--- a/admin/src/api/types.ts
+++ b/admin/src/api/types.ts
@@ -307,8 +307,15 @@ export interface AdminReservationCategoryDto {
     categoryCount: number;         // 카테고리별 예약 건수
 }
 
+// 예약 상태별 예약 건수 타입
+export interface AdminReservationStatusCountDto {
+    reservationStatus: string; // 예: 'CANCEL', 'DONE', 'MATCHING', 'WAITING'
+    count: number;
+}
+
 export interface AdminReservationStatisticsResponseDto {
     reservationSummary: AdminReservationStatisticsSummaryDto;
+    reservationStatus: AdminReservationStatusCountDto[]; // 예약 상태별 예약 건수
     dailyList: AdminReservationDailyDto[];
     categoryList: AdminReservationCategoryDto[];
 }

--- a/admin/src/api/types.ts
+++ b/admin/src/api/types.ts
@@ -244,6 +244,8 @@ export interface AdminReviewStatisticsResponseDto {
     avgManagerReviewSatisfaction: number;
     topCustomerList: AdminReviewUserStatDto[];
     topManagerList: AdminReviewUserStatDto[];
+    topCustomerByReviewCount: AdminReviewUserStatDto[];
+    topManagerByReviewCount: AdminReviewUserStatDto[];
 }
 
 export interface AdminReviewUserStatDto {

--- a/admin/src/api/types.ts
+++ b/admin/src/api/types.ts
@@ -269,7 +269,17 @@ export interface AdminMatchingTopManagerDto {
     successCount: number;
 }
 
+// 매칭 통계 일별 데이터 타입
+export interface AdminMatchingDailyDto {
+    date: string; // YYYY-MM-DD
+    requestCount: number;
+    successCount: number;
+    matchingRate: number;
+}
+
+// 매칭 통계 대시보드 및 매니저 TOP 리스트 타입 (dailyMatchingList 포함)
 export interface AdminMatchingStatisticsResponseDto {
     matchingSummary: AdminMatchingStatisticsSummaryDto;
     topManagerList: AdminMatchingTopManagerDto[];
+    dailyMatchingList: AdminMatchingDailyDto[];
 }

--- a/admin/src/api/types.ts
+++ b/admin/src/api/types.ts
@@ -285,3 +285,30 @@ export interface AdminMatchingStatisticsResponseDto {
     topManagerList: AdminMatchingTopManagerDto[];
     dailyMatchingList: AdminMatchingDailyDto[];
 }
+
+// 예약 통계 응답 타입
+export interface AdminReservationStatisticsSummaryDto {
+    totalCount: number;         // 전체 예약 건수
+    cancelCount: number;       // 취소 건수
+    completeCount: number;     // 완료 건수
+    cancelRate: number;        // 취소율 (%)
+    avgUser: number;           // 평균 이용자 수
+}
+
+export interface AdminReservationDailyDto {
+    date: string;                  // 날짜 (YYYY-MM-DD)
+    dailyReservationsCount: number;// 일별 예약 건수
+    dailyCancelCount: number;      // 일별 취소 건수
+    dailyCompletedCount: number;   // 일별 완료 건수
+}
+
+export interface AdminReservationCategoryDto {
+    categoryName: string;          // 카테고리명
+    categoryCount: number;         // 카테고리별 예약 건수
+}
+
+export interface AdminReservationStatisticsResponseDto {
+    reservationSummary: AdminReservationStatisticsSummaryDto;
+    dailyList: AdminReservationDailyDto[];
+    categoryList: AdminReservationCategoryDto[];
+}

--- a/admin/src/api/types.ts
+++ b/admin/src/api/types.ts
@@ -261,6 +261,8 @@ export interface AdminMatchingStatisticsSummaryDto {
     totalMatchingCount: number; // 전체 매칭 건수
     successCount: number; // 성공 건수
     failCount: number; // 실패 건수
+    customerRefuseRate: number; // 수요자 무응답/거절률
+    managerRefuseRate: number; // 매니저 무응답/거절률
 }
 
 export interface AdminMatchingTopManagerDto {

--- a/admin/src/api/types.ts
+++ b/admin/src/api/types.ts
@@ -254,3 +254,22 @@ export interface AdminReviewUserStatDto {
     avgReview: number;
     totalReviewCount: number;
 }
+
+// 매칭 통계 대시보드 및 매니저 TOP 리스트 타입
+export interface AdminMatchingStatisticsSummaryDto {
+    matchingRating: number; // 매칭 성공률 (%)
+    totalMatchingCount: number; // 전체 매칭 건수
+    successCount: number; // 성공 건수
+    failCount: number; // 실패 건수
+}
+
+export interface AdminMatchingTopManagerDto {
+    managerId: number;
+    managerName: string;
+    successCount: number;
+}
+
+export interface AdminMatchingStatisticsResponseDto {
+    matchingSummary: AdminMatchingStatisticsSummaryDto;
+    topManagerList: AdminMatchingTopManagerDto[];
+}

--- a/admin/src/pages/admin/StatMatching.tsx
+++ b/admin/src/pages/admin/StatMatching.tsx
@@ -1,134 +1,79 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../components/ui/card';
+import { fetchAdminMatchingStatistics } from '../../api/adminMatching';
+import { AdminMatchingStatisticsResponseDto } from '../../api/types';
 
-const stats = [
-  { label: '전체 매칭률', value: '78%', desc: '지난 30일 기준' },
-  { label: '총 매칭 시도', value: '1,500건', desc: '누적' },
-  { label: '매칭 성공', value: '1,170건', desc: '누적' },
-  { label: '매칭 실패', value: '330건', desc: '누적' },
-];
+export const StatMatching: React.FC = () => {
+  const [data, setData] = useState<AdminMatchingStatisticsResponseDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-const trendData = [
-  { date: '06-01', matching: 80 },
-  { date: '06-02', matching: 77 },
-  { date: '06-03', matching: 79 },
-  { date: '06-04', matching: 81 },
-  { date: '06-05', matching: 76 },
-  { date: '06-06', matching: 78 },
-  { date: '06-07', matching: 80 },
-];
+  useEffect(() => {
+    setLoading(true);
+    fetchAdminMatchingStatistics()
+      .then(setData)
+      .catch((e) => setError(e.message || '에러 발생'))
+      .finally(() => setLoading(false));
+  }, []);
 
-const regionStats = [
-  { region: '서울', matching: 82 },
-  { region: '경기', matching: 79 },
-  { region: '부산', matching: 75 },
-  { region: '대구', matching: 73 },
-  { region: '광주', matching: 70 },
-];
+  if (loading) return <div>로딩 중...</div>;
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!data) return <div>데이터 없음</div>;
 
-const topManagers = [
-  { name: '김매니저', matching: 32 },
-  { name: '이매니저', matching: 29 },
-  { name: '박매니저', matching: 27 },
-  { name: '최매니저', matching: 25 },
-  { name: '정매니저', matching: 24 },
-];
+  const stats = [
+    { label: '전체 매칭률', value: `${data.matchingSummary.matchingRating}%`, desc: '누적' },
+    { label: '총 매칭 시도', value: `${data.matchingSummary.totalMatchingCount}건`, desc: '누적' },
+    { label: '매칭 성공', value: `${data.matchingSummary.successCount}건`, desc: '누적' },
+    { label: '매칭 실패', value: `${data.matchingSummary.failCount}건`, desc: '누적' },
+  ];
 
-export const StatMatching: React.FC = () => (
-  <div className="space-y-8">
-    <h1 className="text-2xl font-bold">매칭률</h1>
-    <p className="text-gray-600 mb-4">전체 및 지역/매니저별 매칭률을 확인하세요.</p>
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">매칭률</h1>
+      <p className="text-gray-600 mb-4">전체 및 매니저별 매칭률을 확인하세요.</p>
 
-    {/* 주요 지표 카드 */}
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-      {stats.map((s) => (
-        <Card key={s.label}>
-          <CardHeader>
-            <CardTitle className="text-base font-medium">{s.label}</CardTitle>
-            <CardDescription className="text-xs">{s.desc}</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-blue-700">{s.value}</div>
-          </CardContent>
-        </Card>
-      ))}
-    </div>
+      {/* 주요 지표 카드 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {stats.map((s) => (
+          <Card key={s.label}>
+            <CardHeader>
+              <CardTitle className="text-base font-medium">{s.label}</CardTitle>
+              <CardDescription className="text-xs">{s.desc}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold text-blue-700">{s.value}</div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
 
-    {/* 트렌드 테이블 (샘플) */}
-    <Card>
-      <CardHeader>
-        <CardTitle>최근 7일간 매칭률 트렌드</CardTitle>
-        <CardDescription>일별 매칭률 변화</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="overflow-x-auto">
+      {/* 매니저별 매칭 성공 TOP5 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>매니저별 매칭 성공 TOP5</CardTitle>
+          <CardDescription>최근 한 달 기준</CardDescription>
+        </CardHeader>
+        <CardContent>
           <table className="min-w-full text-center text-sm">
             <thead>
               <tr className="bg-gray-50">
-                <th className="p-2">날짜</th>
-                <th className="p-2">매칭률(%)</th>
+                <th className="p-2">순위</th>
+                <th className="p-2">매니저명</th>
+                <th className="p-2">매칭 성공 건수</th>
               </tr>
             </thead>
             <tbody>
-              {trendData.map((d) => (
-                <tr key={d.date} className="border-b">
-                  <td className="p-2 font-medium">{d.date}</td>
-                  <td className="p-2">{d.matching}</td>
+              {data.topManagerList.map((m, i) => (
+                <tr key={m.managerId} className="border-b">
+                  <td className="p-2 font-bold">{i + 1}</td>
+                  <td className="p-2">{m.managerName}</td>
+                  <td className="p-2">{m.successCount}</td>
                 </tr>
               ))}
             </tbody>
           </table>
-        </div>
-      </CardContent>
-    </Card>
-
-    {/* 지역별 매칭률 */}
-    <Card>
-      <CardHeader>
-        <CardTitle>지역별 매칭률</CardTitle>
-        <CardDescription>주요 지역별 매칭 성공률</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-col gap-2">
-          {regionStats.map((r) => (
-            <div key={r.region} className="flex items-center">
-              <div className="w-16 text-sm text-gray-700">{r.region}</div>
-              <div className="flex-1 bg-gray-200 rounded h-3 mx-2">
-                <div className="bg-blue-500 h-3 rounded" style={{ width: `${r.matching}%` }} />
-              </div>
-              <div className="w-10 text-right text-sm font-bold text-blue-700">{r.matching}%</div>
-            </div>
-          ))}
-        </div>
-      </CardContent>
-    </Card>
-
-    {/* 매니저별 매칭 성공 TOP5 */}
-    <Card>
-      <CardHeader>
-        <CardTitle>매니저별 매칭 성공 TOP5</CardTitle>
-        <CardDescription>최근 한 달 기준</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <table className="min-w-full text-center text-sm">
-          <thead>
-            <tr className="bg-gray-50">
-              <th className="p-2">순위</th>
-              <th className="p-2">매니저명</th>
-              <th className="p-2">매칭 성공 건수</th>
-            </tr>
-          </thead>
-          <tbody>
-            {topManagers.map((m, i) => (
-              <tr key={m.name} className="border-b">
-                <td className="p-2 font-bold">{i + 1}</td>
-                <td className="p-2">{m.name}</td>
-                <td className="p-2">{m.matching}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </CardContent>
-    </Card>
-  </div>
-); 
+        </CardContent>
+      </Card>
+    </div>
+  );
+}; 

--- a/admin/src/pages/admin/StatMatching.tsx
+++ b/admin/src/pages/admin/StatMatching.tsx
@@ -74,6 +74,38 @@ export const StatMatching: React.FC = () => {
           </table>
         </CardContent>
       </Card>
+
+      {/* 일별 매칭률 트렌드 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>최근 7일간 매칭률 트렌드</CardTitle>
+          <CardDescription>일별 매칭률, 시도/성공 건수</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-center text-sm">
+              <thead>
+                <tr className="bg-gray-50">
+                  <th className="p-2">날짜</th>
+                  <th className="p-2">매칭률(%)</th>
+                  <th className="p-2">시도 건수</th>
+                  <th className="p-2">성공 건수</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.dailyMatchingList.map((d) => (
+                  <tr key={d.date} className="border-b">
+                    <td className="p-2 font-medium">{d.date}</td>
+                    <td className="p-2 text-blue-700 font-bold">{d.matchingRate}</td>
+                    <td className="p-2">{d.requestCount}</td>
+                    <td className="p-2">{d.successCount}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }; 

--- a/admin/src/pages/admin/StatMatching.tsx
+++ b/admin/src/pages/admin/StatMatching.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../components/ui/card';
 import { fetchAdminMatchingStatistics } from '../../api/adminMatching';
 import { AdminMatchingStatisticsResponseDto } from '../../api/types';
+import { ResponsiveContainer, BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
 
 export const StatMatching: React.FC = () => {
   const [data, setData] = useState<AdminMatchingStatisticsResponseDto | null>(null);
@@ -83,7 +84,7 @@ export const StatMatching: React.FC = () => {
         </CardHeader>
         <CardContent>
           <div className="overflow-x-auto">
-            <table className="min-w-full text-center text-sm">
+            <table className="min-w-full text-center text-sm mb-6">
               <thead>
                 <tr className="bg-gray-50">
                   <th className="p-2">날짜</th>
@@ -103,6 +104,21 @@ export const StatMatching: React.FC = () => {
                 ))}
               </tbody>
             </table>
+            {/* 막대+선 그래프 */}
+            <div className="h-[300px] w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={data.dailyMatchingList} margin={{ top: 20, right: 30, left: 0, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="date" />
+                  <YAxis yAxisId="left" orientation="left" />
+                  <YAxis yAxisId="right" orientation="right" domain={[0, 100]} />
+                  <Tooltip />
+                  <Bar yAxisId="left" dataKey="requestCount" fill="#a3a3a3" name="시도 건수" barSize={24} />
+                  <Bar yAxisId="left" dataKey="successCount" fill="#3b82f6" name="성공 건수" barSize={24} />
+                  <Line yAxisId="right" type="monotone" dataKey="matchingRate" stroke="#2563eb" strokeWidth={3} dot={{ r: 5, fill: '#2563eb' }} name="매칭률(%)" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/admin/src/pages/admin/StatMatching.tsx
+++ b/admin/src/pages/admin/StatMatching.tsx
@@ -48,6 +48,28 @@ export const StatMatching: React.FC = () => {
         ))}
       </div>
 
+      {/* 수요자/매니저 무응답·거절률 카드 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-medium">수요자 무응답·거절률</CardTitle>
+            <CardDescription className="text-xs">매칭 요청에 응답하지 않거나 거절한 비율</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-red-600">{data.matchingSummary.customerRefuseRate}%</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-medium">매니저 무응답·거절률</CardTitle>
+            <CardDescription className="text-xs">매칭 요청에 응답하지 않거나 거절한 비율</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-red-600">{data.matchingSummary.managerRefuseRate}%</div>
+          </CardContent>
+        </Card>
+      </div>
+
       {/* 매니저별 매칭 성공 TOP5 */}
       <Card>
         <CardHeader>

--- a/admin/src/pages/admin/StatReservation.tsx
+++ b/admin/src/pages/admin/StatReservation.tsx
@@ -1,95 +1,171 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../components/ui/card';
+import { adminReservationService } from '../../api/adminReservation';
+import { AdminReservationStatisticsResponseDto } from '../../api/types';
 
-const stats = [
-  { label: '예약률', value: '65%', desc: '지난 30일 기준' },
-  { label: '취소율', value: '12%', desc: '지난 30일 기준' },
-  { label: '총 예약 건수', value: '1,240건', desc: '누적' },
-  { label: '총 취소 건수', value: '150건', desc: '누적' },
-];
+export const StatReservation: React.FC = () => {
+  const [data, setData] = useState<AdminReservationStatisticsResponseDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-const trendData = [
-  { date: '06-01', reservation: 70, cancel: 10 },
-  { date: '06-02', reservation: 65, cancel: 12 },
-  { date: '06-03', reservation: 68, cancel: 11 },
-  { date: '06-04', reservation: 66, cancel: 13 },
-  { date: '06-05', reservation: 63, cancel: 14 },
-  { date: '06-06', reservation: 67, cancel: 12 },
-  { date: '06-07', reservation: 69, cancel: 10 },
-];
+  useEffect(() => {
+    setLoading(true);
+    adminReservationService.getReservationStatistics(7)
+      .then(setData)
+      .catch((e) => setError(e.message || '에러 발생'))
+      .finally(() => setLoading(false));
+  }, []);
 
-export const StatReservation: React.FC = () => (
-  <div className="space-y-8">
-    <h1 className="text-2xl font-bold">예약률 & 취소율</h1>
-    <p className="text-gray-600 mb-4">예약 성공률과 취소율을 한눈에 확인하세요.</p>
+  if (loading) return <div>로딩 중...</div>;
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!data) return <div>데이터 없음</div>;
 
-    {/* 주요 지표 카드 */}
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-      {stats.map((s) => (
-        <Card key={s.label}>
+  const summary = data.reservationSummary;
+
+  // 예약 상태 한글 변환 및 순서 지정
+  const statusOrder = ['WAITING', 'MATCHING', 'DONE', 'CANCEL'];
+  const statusLabel: Record<string, string> = {
+    WAITING: '대기중',
+    MATCHING: '매칭중',
+    DONE: '완료',
+    CANCEL: '취소'
+  };
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">예약 통계 대시보드</h1>
+      <p className="text-gray-600 mb-4">예약 현황, 일별/카테고리별 통계를 확인하세요.</p>
+
+      {/* 대시보드 카드 - 2줄 배치 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
+        <Card>
           <CardHeader>
-            <CardTitle className="text-base font-medium">{s.label}</CardTitle>
-            <CardDescription className="text-xs">{s.desc}</CardDescription>
+            <CardTitle className="text-base font-medium">전체 예약 건수</CardTitle>
+            <CardDescription className="text-xs">누적</CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-blue-700">{s.value}</div>
+            <div className="text-2xl font-bold text-blue-700">{summary.totalCount.toLocaleString()}건</div>
           </CardContent>
         </Card>
-      ))}
-    </div>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-medium">전체 완료 건수</CardTitle>
+            <CardDescription className="text-xs">누적</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-blue-700">{summary.completeCount.toLocaleString()}건</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-medium">사용자당 평균 예약 수</CardTitle>
+            <CardDescription className="text-xs">수요자 1명 평균 예약</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-blue-700">{summary.avgUser}건</div>
+          </CardContent>
+        </Card>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-4 mb-8">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-medium">전체 취소 건수</CardTitle>
+            <CardDescription className="text-xs">누적</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-red-600">{summary.cancelCount.toLocaleString()}건</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-medium">취소율</CardTitle>
+            <CardDescription className="text-xs">누적</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-red-600">{summary.cancelRate}%</div>
+          </CardContent>
+        </Card>
+      </div>
 
-    {/* 트렌드 테이블 (샘플) */}
-    <Card>
-      <CardHeader>
-        <CardTitle>최근 7일간 예약/취소 트렌드</CardTitle>
-        <CardDescription>예약률과 취소율의 일별 변화</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="overflow-x-auto">
+      {/* 예약 상태별 예약 건수 카드형 대시보드 - 별도 섹션 */}
+      <div className="bg-white rounded-xl border p-6 mb-8">
+        <div className="font-bold text-lg mb-4">예약 상태별 예약 건수</div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {['WAITING', 'MATCHING', 'DONE', 'CANCEL'].map((statusKey) => {
+            const statusLabel: Record<string, string> = {
+              WAITING: '대기중',
+              MATCHING: '매칭중',
+              DONE: '완료',
+              CANCEL: '취소',
+            };
+            const s = data.reservationStatus.find((item) => item.reservationStatus === statusKey);
+            return (
+              <div key={statusKey} className="flex flex-col items-center py-6 border rounded-lg bg-gray-50">
+                <div className="text-base font-medium mb-1">{statusLabel[statusKey]}</div>
+                <div className="text-2xl font-bold text-blue-700">{s ? s.count : 0}</div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* 최근 7일간 일자별 예약/취소/완료 통계 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>최근 7일간 일자별 예약 통계</CardTitle>
+          <CardDescription>일별 예약 현황</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-center text-sm mb-6">
+              <thead>
+                <tr className="bg-gray-50">
+                  <th className="p-2">날짜</th>
+                  <th className="p-2">예약 건수</th>
+                  <th className="p-2">취소 건수</th>
+                  <th className="p-2">완료 건수</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.dailyList.map((d) => (
+                  <tr key={d.date} className="border-b">
+                    <td className="p-2 font-medium">{d.date}</td>
+                    <td className="p-2 text-blue-700 font-bold">{d.dailyReservationsCount}</td>
+                    <td className="p-2">{d.dailyCancelCount}</td>
+                    <td className="p-2">{d.dailyCompletedCount}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 카테고리별 예약 건수 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>카테고리별 예약 건수</CardTitle>
+          <CardDescription>서비스별 예약 현황</CardDescription>
+        </CardHeader>
+        <CardContent>
           <table className="min-w-full text-center text-sm">
             <thead>
               <tr className="bg-gray-50">
-                <th className="p-2">날짜</th>
-                <th className="p-2">예약률(%)</th>
-                <th className="p-2">취소율(%)</th>
+                <th className="p-2">카테고리명</th>
+                <th className="p-2">예약 건수</th>
               </tr>
             </thead>
             <tbody>
-              {trendData.map((d) => (
-                <tr key={d.date} className="border-b">
-                  <td className="p-2 font-medium">{d.date}</td>
-                  <td className="p-2">{d.reservation}</td>
-                  <td className="p-2">{d.cancel}</td>
+              {data.categoryList.map((c) => (
+                <tr key={c.categoryName} className="border-b">
+                  <td className="p-2 font-medium text-black">{c.categoryName}</td>
+                  <td className="p-2 text-black">{c.categoryCount}</td>
                 </tr>
               ))}
             </tbody>
           </table>
-        </div>
-      </CardContent>
-    </Card>
-
-    {/* 예약/취소 비율 그래프 (샘플 바) */}
-    <Card>
-      <CardHeader>
-        <CardTitle>예약/취소 비율</CardTitle>
-        <CardDescription>전체 예약 대비 취소 비율 시각화</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex items-center gap-4">
-          <div className="w-32 text-sm text-gray-700">예약</div>
-          <div className="flex-1 bg-gray-200 rounded h-4">
-            <div className="bg-blue-500 h-4 rounded" style={{ width: '88%' }} />
-          </div>
-          <div className="w-12 text-right text-sm font-bold text-blue-700">88%</div>
-        </div>
-        <div className="flex items-center gap-4 mt-2">
-          <div className="w-32 text-sm text-gray-700">취소</div>
-          <div className="flex-1 bg-gray-200 rounded h-4">
-            <div className="bg-red-400 h-4 rounded" style={{ width: '12%' }} />
-          </div>
-          <div className="w-12 text-right text-sm font-bold text-red-600">12%</div>
-        </div>
-      </CardContent>
-    </Card>
-  </div>
-); 
+        </CardContent>
+      </Card>
+    </div>
+  );
+}; 

--- a/admin/src/pages/admin/StatSatisfaction.tsx
+++ b/admin/src/pages/admin/StatSatisfaction.tsx
@@ -82,7 +82,7 @@ export const StatSatisfaction: React.FC = () => {
               </tr>
             </thead>
             <tbody>
-              {data.topCustomerList.map((u) => (
+              {(data.topCustomerList || []).map((u) => (
                 <tr key={u.userId} className="border-b">
                   <td className="p-2">{u.userId}</td>
                   <td className="p-2 font-medium">{u.userName}</td>
@@ -112,7 +112,67 @@ export const StatSatisfaction: React.FC = () => {
               </tr>
             </thead>
             <tbody>
-              {data.topManagerList.map((m) => (
+              {(data.topManagerList || []).map((m) => (
+                <tr key={m.userId} className="border-b">
+                  <td className="p-2">{m.userId}</td>
+                  <td className="p-2 font-medium">{m.userName}</td>
+                  <td className="p-2 text-blue-700 font-bold">{m.avgReview}</td>
+                  <td className="p-2">{m.totalReviewCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      {/* 리뷰 많은 사용자 TOP3 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>리뷰 많은 사용자 TOP3</CardTitle>
+          <CardDescription>누적 리뷰 수 기준</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <table className="min-w-full text-center text-sm">
+            <thead>
+              <tr className="bg-gray-50">
+                <th className="p-2">ID</th>
+                <th className="p-2">이름</th>
+                <th className="p-2">평균 평점</th>
+                <th className="p-2">리뷰 수</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(data.topCustomerByReviewCount || []).map((u) => (
+                <tr key={u.userId} className="border-b">
+                  <td className="p-2">{u.userId}</td>
+                  <td className="p-2 font-medium">{u.userName}</td>
+                  <td className="p-2 text-blue-700 font-bold">{u.avgReview}</td>
+                  <td className="p-2">{u.totalReviewCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      {/* 리뷰 많은 매니저 TOP3 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>리뷰 많은 매니저 TOP3</CardTitle>
+          <CardDescription>누적 리뷰 수 기준</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <table className="min-w-full text-center text-sm">
+            <thead>
+              <tr className="bg-gray-50">
+                <th className="p-2">ID</th>
+                <th className="p-2">이름</th>
+                <th className="p-2">평균 평점</th>
+                <th className="p-2">리뷰 수</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(data.topManagerByReviewCount || []).map((m) => (
                 <tr key={m.userId} className="border-b">
                   <td className="p-2">{m.userId}</td>
                   <td className="p-2 font-medium">{m.userName}</td>

--- a/apps/src/app/(user)/(standalone)/matching/MatchingPageClient.tsx
+++ b/apps/src/app/(user)/(standalone)/matching/MatchingPageClient.tsx
@@ -8,9 +8,7 @@ import type { Manager } from '@/widgets/manager/model/manager'
 
 // 매니저 매칭 알고리즘 함수 (추후 확장 가능)
 function getMatchedManagers(managers: Manager[], count: number = 5): Manager[] {
-  
-  // return managers.slice(0, count)
-  return managers // 임시: 전체 매니저 반환 (테스트용)
+  return managers.slice(0, count)
 }
 
 export default function MatchingPageClient() {


### PR DESCRIPTION
- #190 
- #193 
- #194 

📌 예약 통계 기능 구현
- 관리자용 예약 통계 API /api/v1/admin/statistics/reservations 구현
- 전체 예약 수, 취소 수, 완료 수, 취소율, 사용자당 평균 예약 수 포함
- 최근 N일 기준 일자별 예약 현황 조회
- 카테고리별 예약 건수 집계
- 예약 상태별 건수 통계 추가 (WAITING, DONE, CANCEL, 등등)