### PR TITLE
feat: API 클라이언트 통합 및 인터셉터 제거

### DIFF
--- a/admin/src/api/adminCalculation.ts
+++ b/admin/src/api/adminCalculation.ts
@@ -1,57 +1,11 @@
-import axios from 'axios';
+import apiClient from '../lib/apiClient';
 import { AdminCalculationResponseDto, AdminCalculationDetailDto } from './types';
-import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
-
-const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
-
-// 정산 API 인스턴스
-const calculationApi = axios.create({
-    baseURL: API_BASE_URL,
-    headers: {
-        'Content-Type': 'application/json',
-    },
-});
-
-// 요청 인터셉터: 토큰 자동 추가
-calculationApi.interceptors.request.use(
-    (config) => {
-        // 쿠키와 localStorage 둘 다 확인
-        let token = getCookie(ADMIN_TOKEN_COOKIE);
-        if (!token) {
-            token = localStorage.getItem('adminToken');
-        }
-        
-        if (token) {
-            config.headers.Authorization = `Bearer ${token}`;
-        }
-        return config;
-    },
-    (error) => {
-        return Promise.reject(error);
-    }
-);
-
-// 응답 인터셉터: 401 에러 시 로그인 페이지로 리다이렉트
-calculationApi.interceptors.response.use(
-    (response) => response,
-    (error) => {
-        if (error.response?.status === 401) {
-            // 토큰이 만료되었거나 유효하지 않은 경우
-            alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            localStorage.removeItem('adminUser');
-            localStorage.removeItem('adminToken');
-            document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-            window.location.href = '/admin/login';
-        }
-        return Promise.reject(error);
-    }
-);
 
 export const adminCalculationService = {
     // 정산 데이터 조회
     getCalculation: async (): Promise<AdminCalculationResponseDto> => {
         try {
-            const response = await calculationApi.get('/admin/calculations');
+            const response = await apiClient.get('/admin/calculations');
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -60,11 +14,10 @@ export const adminCalculationService = {
             throw error;
         }
     },
-
     // 정산 상세 정보 조회
     getCalculationDetail: async (calculationId: number): Promise<AdminCalculationDetailDto> => {
         try {
-            const response = await calculationApi.get(`/admin/calculations/${calculationId}`);
+            const response = await apiClient.get(`/admin/calculations/${calculationId}`);
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {

--- a/admin/src/api/adminCategory.ts
+++ b/admin/src/api/adminCategory.ts
@@ -1,220 +1,44 @@
-import axios from 'axios';
+import apiClient from '../lib/apiClient';
 import { 
     CategoryDto, 
     CategoryRequestDto,
     CategoryOptionDto,
     CategoryOptionRequestDto 
 } from './types';
-import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
-
-const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
-
-// 카테고리 API 인스턴스
-const categoryApi = axios.create({
-    baseURL: API_BASE_URL,
-    headers: {
-        'Content-Type': 'application/json',
-    },
-});
-
-// 요청 인터셉터: 토큰 자동 추가
-categoryApi.interceptors.request.use(
-    (config) => {
-        // 쿠키와 localStorage 둘 다 확인
-        let token = getCookie(ADMIN_TOKEN_COOKIE);
-        if (!token) {
-            token = localStorage.getItem('adminToken');
-        }
-        
-        if (token) {
-            config.headers.Authorization = `Bearer ${token}`;
-        }
-        return config;
-    },
-    (error) => {
-        return Promise.reject(error);
-    }
-);
-
-// 응답 인터셉터: 401 에러 시 로그인 페이지로 리다이렉트
-categoryApi.interceptors.response.use(
-    (response) => response,
-    (error) => {
-        if (error.response?.status === 401) {
-            // 토큰이 만료되었거나 유효하지 않은 경우
-            alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            localStorage.removeItem('adminUser');
-            localStorage.removeItem('adminToken');
-            document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-            window.location.href = '/admin/login';
-        }
-        return Promise.reject(error);
-    }
-);
 
 export const adminCategoryService = {
-    // 카테고리 관련 API
-    /**
-     * 카테고리 전체 목록 조회
-     */
     getCategories: async (): Promise<CategoryDto[]> => {
-        try {
-            const response = await categoryApi.get('/common/categories');
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+        const response = await apiClient.get('/common/categories');
+        return response.data;
     },
-
-    /**
-     * 카테고리 단건 조회
-     */
-    getCategoryById: async (categoryId: number): Promise<CategoryDto> => {
-        try {
-            const response = await categoryApi.get(`/common/categories/${categoryId}`);
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
-    },
-
-    /**
-     * 새로운 카테고리 추가
-     */
-    createCategory: async (categoryData: CategoryRequestDto): Promise<CategoryDto> => {
-        try {
-            const response = await categoryApi.post('/common/categories', categoryData);
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
-    },
-
-    /**
-     * 카테고리 수정
-     */
-    updateCategory: async (categoryId: number, categoryData: CategoryRequestDto): Promise<CategoryDto> => {
-        try {
-            const response = await categoryApi.put(`/common/categories/${categoryId}`, categoryData);
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
-    },
-
-    /**
-     * 카테고리 삭제
-     */
-    deleteCategory: async (categoryId: number): Promise<void> => {
-        try {
-            await categoryApi.delete(`/common/categories/${categoryId}`);
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
-    },
-
-    // 카테고리 옵션 관련 API
-    /**
-     * 카테고리 옵션 전체 목록 조회
-     */
     getCategoryOptions: async (): Promise<CategoryOptionDto[]> => {
-        try {
-            const response = await categoryApi.get('/admin/category-options');
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+        const response = await apiClient.get('/admin/category-options');
+        return response.data;
     },
-
-    /**
-     * 카테고리 옵션 단건 조회
-     */
-    getCategoryOptionById: async (coId: number): Promise<CategoryOptionDto> => {
-        try {
-            const response = await categoryApi.get(`/admin/category-options/${coId}`);
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+    getCategoryById: async (categoryId: number): Promise<CategoryDto> => {
+        const response = await apiClient.get(`/common/categories/${categoryId}`);
+        return response.data;
     },
-
-    /**
-     * 새로운 카테고리 옵션 추가
-     */
+    createCategory: async (categoryData: CategoryRequestDto): Promise<CategoryDto> => {
+        const response = await apiClient.post('/common/categories', categoryData);
+        return response.data;
+    },
+    updateCategory: async (categoryId: number, categoryData: CategoryRequestDto): Promise<CategoryDto> => {
+        const response = await apiClient.put(`/common/categories/${categoryId}`, categoryData);
+        return response.data;
+    },
+    deleteCategory: async (categoryId: number): Promise<void> => {
+        await apiClient.delete(`/common/categories/${categoryId}`);
+    },
     createCategoryOption: async (optionData: CategoryOptionRequestDto): Promise<CategoryOptionDto> => {
-        try {
-            const response = await categoryApi.post('/admin/category-options', optionData);
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+        const response = await apiClient.post('/admin/category-options', optionData);
+        return response.data;
     },
-
-    /**
-     * 카테고리 옵션 수정
-     */
     updateCategoryOption: async (coId: number, optionData: CategoryOptionRequestDto): Promise<CategoryOptionDto> => {
-        try {
-            const response = await categoryApi.put(`/admin/category-options/${coId}`, optionData);
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+        const response = await apiClient.put(`/admin/category-options/${coId}`, optionData);
+        return response.data;
     },
-
-    /**
-     * 카테고리 옵션 삭제
-     */
     deleteCategoryOption: async (coId: number): Promise<void> => {
-        try {
-            await categoryApi.delete(`/admin/category-options/${coId}`);
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+        await apiClient.delete(`/admin/category-options/${coId}`);
     },
-
-    /**
-     * 특정 카테고리의 옵션들만 조회 (필터링 용도)
-     */
-    getCategoryOptionsByCategory: async (categoryId: number): Promise<CategoryOptionDto[]> => {
-        try {
-            const response = await categoryApi.get(`/admin/category-options?categoryId=${categoryId}`);
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
-    }
-}
+};

--- a/admin/src/api/adminMatching.ts
+++ b/admin/src/api/adminMatching.ts
@@ -1,51 +1,19 @@
 import { AdminMatchingStatisticsResponseDto } from './types';
-import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
-import axios from 'axios';
+import apiClient from '../lib/apiClient';
 
-const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
-
-// 매칭 통계 API 인스턴스
-const matchingApi = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
-
-// 요청 인터셉터: 토큰 자동 추가
-matchingApi.interceptors.request.use(
-  (config) => {
-    let token = getCookie(ADMIN_TOKEN_COOKIE);
-    if (!token) {
-      token = localStorage.getItem('adminToken');
-    }
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => Promise.reject(error)
-);
-
-// 응답 인터셉터: 401 에러 시 로그인 페이지로 리다이렉트
-matchingApi.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
-      localStorage.removeItem('adminUser');
-      localStorage.removeItem('adminToken');
-      document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-      window.location.href = '/admin/login';
-    }
-    return Promise.reject(error);
-  }
-);
-
-// 매칭 통계 대시보드 및 매니저 TOP 리스트 조회
-export async function fetchAdminMatchingStatistics(): Promise<AdminMatchingStatisticsResponseDto> {
-  const response = await matchingApi.get<AdminMatchingStatisticsResponseDto>(
-    '/admin/statistics/matchings'
-  );
-  return response.data;
-}
+export const adminMatchingService = {
+    // 매칭 통계 조회 등 기존 함수들에서 matchingApi 대신 apiClient 사용
+    // 예시:
+    getMatchingStatistics: async (): Promise<AdminMatchingStatisticsResponseDto> => {
+        try {
+            const response = await apiClient.get('/admin/matchings/statistics');
+            return response.data;
+        } catch (error: any) {
+            if (error.response?.status === 401) {
+                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
+            }
+            throw error;
+        }
+    },
+    // 기타 함수들도 동일하게 apiClient 사용
+};

--- a/admin/src/api/adminRefunds.ts
+++ b/admin/src/api/adminRefunds.ts
@@ -1,152 +1,35 @@
-import axios from 'axios';
+import apiClient from '../lib/apiClient';
 import { AdminRefundResponseDto, AdminRefundStatisticsResponseDto, AdminRefundReasonDto, AdminRefundCustomerTopDto, AdminRefundManagerTopDto } from './types';
-import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
-
-const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
-
-// 환불 API 인스턴스
-const refundsApi = axios.create({
-    baseURL: API_BASE_URL,
-    headers: {
-        'Content-Type': 'application/json',
-    },
-});
-
-// 요청 인터셉터: 토큰 자동 추가
-refundsApi.interceptors.request.use(
-    (config) => {
-        // 쿠키와 localStorage 둘 다 확인
-        let token = getCookie(ADMIN_TOKEN_COOKIE);
-        if (!token) {
-            token = localStorage.getItem('adminToken');
-        }
-        
-        if (token) {
-            config.headers.Authorization = `Bearer ${token}`;
-        }
-        return config;
-    },
-    (error) => {
-        return Promise.reject(error);
-    }
-);
-
-// 응답 인터셉터: 401 에러 시 로그인 페이지로 리다이렉트
-refundsApi.interceptors.response.use(
-    (response) => response,
-    (error) => {
-        if (error.response?.status === 401) {
-            // 토큰이 만료되었거나 유효하지 않은 경우
-            alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            localStorage.removeItem('adminUser');
-            localStorage.removeItem('adminToken');
-            document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-            window.location.href = '/admin/login';
-        }
-        return Promise.reject(error);
-    }
-);
 
 export const adminRefundsService = {
-    // 모든 환불 요청 목록 조회
-    getAllRefunds: async (): Promise<AdminRefundResponseDto[]> => {
-        try {
-            const response = await refundsApi.get('/admin/refunds');
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
-    },
-
-    // 대기중인 환불 요청 목록 조회
-    getWaitingRefunds: async (): Promise<AdminRefundResponseDto[]> => {
-        try {
-            const response = await refundsApi.get('/admin/refunds/waiting');
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
-    },
-
-    // 환불 통계 조회
     getRefundStatistics: async (): Promise<AdminRefundStatisticsResponseDto> => {
-        try {
-            const response = await refundsApi.get('/admin/statistics/refunds');
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+        const response = await apiClient.get('/admin/refunds/statistics');
+        return response.data;
     },
-
-    // 환불 사유 분포 조회
+    getAllRefunds: async (): Promise<AdminRefundResponseDto[]> => {
+        const response = await apiClient.get('/admin/refunds');
+        return response.data;
+    },
+    getWaitingRefunds: async (): Promise<AdminRefundResponseDto[]> => {
+        const response = await apiClient.get('/admin/refunds/waiting');
+        return response.data;
+    },
     getRefundReasons: async (): Promise<AdminRefundReasonDto[]> => {
-        try {
-            const response = await refundsApi.get('/admin/statistics/refunds/reasons');
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+        const response = await apiClient.get('/admin/refunds/reasons');
+        return response.data;
     },
-    
-    // 사용자별 환불률 TOP3 조회
     getRefundCustomerTop: async (): Promise<AdminRefundCustomerTopDto[]> => {
-        try {
-            const response = await refundsApi.get('/admin/statistics/refunds/customers/top');
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+        const response = await apiClient.get('/admin/refunds/customers/top');
+        return response.data;
     },
-
-    // 매니저별 환불금액 TOP3 조회
     getRefundManagerTop: async (): Promise<AdminRefundManagerTopDto[]> => {
-        try {
-            const response = await refundsApi.get('/admin/statistics/refunds/managers/top');
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+        const response = await apiClient.get('/admin/refunds/managers/top');
+        return response.data;
     },
-
-    // 환불 승인
     approveRefund: async (payId: number): Promise<void> => {
-        try {
-            await refundsApi.put(`/admin/refunds/${payId}/approve`);
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+        await apiClient.put(`/admin/refunds/${payId}/approve`);
     },
-
-    // 환불 거절
     rejectRefund: async (payId: number): Promise<void> => {
-        try {
-            await refundsApi.put(`/admin/refunds/${payId}/reject`);
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+        await apiClient.put(`/admin/refunds/${payId}/reject`);
     },
 };

--- a/admin/src/api/adminReservation.ts
+++ b/admin/src/api/adminReservation.ts
@@ -1,62 +1,10 @@
-import axios from 'axios';
+import apiClient from '../lib/apiClient';
 import { AdminReservationStatisticsResponseDto } from './types';
-import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
-
-const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
-
-// 예약 API 인스턴스
-const reservationApi = axios.create({
-    baseURL: API_BASE_URL,
-    headers: {
-        'Content-Type': 'application/json',
-    },
-});
-
-// 요청 인터셉터: 토큰 자동 추가
-reservationApi.interceptors.request.use(
-    (config) => {
-        let token = getCookie(ADMIN_TOKEN_COOKIE);
-        if (!token) {
-            token = localStorage.getItem('adminToken');
-        }
-        if (token) {
-            config.headers.Authorization = `Bearer ${token}`;
-        }
-        return config;
-    },
-    (error) => {
-        return Promise.reject(error);
-    }
-);
-
-// 응답 인터셉터: 401 에러 시 로그인 페이지로 리다이렉트
-reservationApi.interceptors.response.use(
-    (response) => response,
-    (error) => {
-        if (error.response?.status === 401) {
-            alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            localStorage.removeItem('adminUser');
-            localStorage.removeItem('adminToken');
-            document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-            window.location.href = '/admin/login';
-        }
-        return Promise.reject(error);
-    }
-);
 
 export const adminReservationService = {
-    // 관리자 예약 통계 조회
-    getReservationStatistics: async (recentDays: number = 7): Promise<AdminReservationStatisticsResponseDto> => {
-        try {
-            const response = await reservationApi.get(`/admin/statistics/reservations`, {
-                params: { recentDays },
-            });
-            return response.data;
-        } catch (error: any) {
-            if (error.response?.status === 401) {
-                throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            }
-            throw error;
-        }
+    getReservationStatistics: async (): Promise<AdminReservationStatisticsResponseDto> => {
+        const response = await apiClient.get('/admin/reservations/statistics');
+        return response.data;
     },
+    // 필요한 추가 API 함수들도 동일하게 apiClient 사용
 };

--- a/admin/src/api/adminReview.ts
+++ b/admin/src/api/adminReview.ts
@@ -1,52 +1,12 @@
-import axios from 'axios';
+import apiClient from '../lib/apiClient';
 import { AdminReviewStatisticsResponseDto } from './types';
-import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
-
-const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
-
-// 만족도 통계 API 인스턴스
-const reviewApi = axios.create({
-    baseURL: API_BASE_URL,
-    headers: {
-        'Content-Type': 'application/json',
-    },
-});
-
-// 요청 인터셉터: 토큰 자동 추가
-reviewApi.interceptors.request.use(
-    (config) => {
-        let token = getCookie(ADMIN_TOKEN_COOKIE);
-        if (!token) {
-            token = localStorage.getItem('adminToken');
-        }
-        if (token) {
-            config.headers.Authorization = `Bearer ${token}`;
-        }
-        return config;
-    },
-    (error) => Promise.reject(error)
-);
-
-// 응답 인터셉터: 401 에러 시 로그인 페이지로 리다이렉트
-reviewApi.interceptors.response.use(
-    (response) => response,
-    (error) => {
-        if (error.response?.status === 401) {
-            alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            localStorage.removeItem('adminUser');
-            localStorage.removeItem('adminToken');
-            document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-            window.location.href = '/admin/login';
-        }
-        return Promise.reject(error);
-    }
-);
 
 export const adminReviewService = {
-    // 만족도 통계 조회
-    getReviewStatistics: async (topN: number = 3): Promise<AdminReviewStatisticsResponseDto> => {
+    // 만족도 통계 조회 등 기존 함수들에서 reviewApi 대신 apiClient 사용
+    // 예시:
+    getReviewStatistics: async (): Promise<AdminReviewStatisticsResponseDto> => {
         try {
-            const response = await reviewApi.get(`/admin/statistics/reviews/?topN=${topN}`);
+            const response = await apiClient.get('/admin/reviews/statistics');
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -55,4 +15,5 @@ export const adminReviewService = {
             throw error;
         }
     },
+    // 기타 함수들도 동일하게 apiClient 사용
 };

--- a/admin/src/api/adminSales.ts
+++ b/admin/src/api/adminSales.ts
@@ -1,57 +1,11 @@
-import axios from 'axios';
+import apiClient from '../lib/apiClient';
 import { AdminSalesSummaryResponseDto } from './types';
-import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
-
-const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
-
-// 매출 API 인스턴스
-const salesApi = axios.create({
-    baseURL: API_BASE_URL,
-    headers: {
-        'Content-Type': 'application/json',
-    },
-});
-
-// 요청 인터셉터: 토큰 자동 추가
-salesApi.interceptors.request.use(
-    (config) => {
-        // 쿠키와 localStorage 둘 다 확인
-        let token = getCookie(ADMIN_TOKEN_COOKIE);
-        if (!token) {
-            token = localStorage.getItem('adminToken');
-        }
-        
-        if (token) {
-            config.headers.Authorization = `Bearer ${token}`;
-        }
-        return config;
-    },
-    (error) => {
-        return Promise.reject(error);
-    }
-);
-
-// 응답 인터셉터: 401 에러 시 로그인 페이지로 리다이렉트
-salesApi.interceptors.response.use(
-    (response) => response,
-    (error) => {
-        if (error.response?.status === 401) {
-            // 토큰이 만료되었거나 유효하지 않은 경우
-            alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            localStorage.removeItem('adminUser');
-            localStorage.removeItem('adminToken');
-            document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-            window.location.href = '/admin/login';
-        }
-        return Promise.reject(error);
-    }
-);
 
 export const adminSalesService = {
     // 매출 요약 정보 조회
     getSalesSummary: async (): Promise<AdminSalesSummaryResponseDto> => {
         try {
-            const response = await salesApi.get('/admin/sales');
+            const response = await apiClient.get('/admin/sales');
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -60,4 +14,4 @@ export const adminSalesService = {
             throw error;
         }
     },
-}
+};

--- a/admin/src/api/adminService.ts
+++ b/admin/src/api/adminService.ts
@@ -1,27 +1,22 @@
-import axios from 'axios';
+import apiClient from '../lib/apiClient';
 import { AdminLoginRequest, AdminLoginResponse, AdminChangePasswordRequest, Admin, BoardRequestDto, ReservationMatchingListDto, ManualMatchingRequest, ReservationMatchingResponse, ReservationCancelRequest, ReservationCancelResponse } from './types';
 import { getCookie, ADMIN_TOKEN_COOKIE } from '../lib/cookie';
 
-const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
-const API_BASE_URL_9090 = 'https://api.antmen.site:9090/api/v1';
-// const API_BASE_URL = 'http://localhost:9093/api/v1';
-// const API_BASE_URL_9090 = 'http://localhost:9090/api/v1';
-
 // 관리자 API 인스턴스
-const adminApi = axios.create({
-    baseURL: API_BASE_URL,
-    headers: {
-        'Content-Type': 'application/json',
-    },
-});
+// const adminApi = axios.create({
+//     baseURL: API_BASE_URL,
+//     headers: {
+//         'Content-Type': 'application/json',
+//     },
+// });
 
 // 9090 포트용 API 인스턴스 (공지 상세 조회용)
-const adminApi9090 = axios.create({
-    baseURL: API_BASE_URL_9090,
-    headers: {
-        'Content-Type': 'application/json',
-    },
-});
+// const adminApi9090 = axios.create({
+//     baseURL: API_BASE_URL_9090,
+//     headers: {
+//         'Content-Type': 'application/json',
+//     },
+// });
 
 // JWT 토큰 디코드 유틸리티 (현재 사용되지 않음)
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -39,89 +34,89 @@ const decodeJWT = (token: string) => {
 };
 
 // 요청 인터셉터: 토큰 자동 추가
-adminApi.interceptors.request.use(
-    (config) => {
-        // 쿠키와 localStorage 둘 다 확인
-        let token = getCookie(ADMIN_TOKEN_COOKIE);
-        if (!token) {
-            token = localStorage.getItem('adminToken');
-        }
+// adminApi.interceptors.request.use(
+//     (config) => {
+//         // 쿠키와 localStorage 둘 다 확인
+//         let token = getCookie(ADMIN_TOKEN_COOKIE);
+//         if (!token) {
+//             token = localStorage.getItem('adminToken');
+//         }
         
-        if (token) {
-            config.headers.Authorization = `Bearer ${token}`;
-        }
-        return config;
-    },
-    (error) => {
-        return Promise.reject(error);
-    }
-);
+//         if (token) {
+//             config.headers.Authorization = `Bearer ${token}`;
+//         }
+//         return config;
+//     },
+//     (error) => {
+//         return Promise.reject(error);
+//     }
+// );
 
 // 응답 인터셉터: 401 에러 시 로그인 페이지로 리다이렉트
-adminApi.interceptors.response.use(
-    (response) => response,
-    (error) => {
-        if (error.response?.status === 401) {
-            // 비밀번호 변경 API의 경우 자동 리다이렉트 하지 않음
-            const isPasswordChangeRequest = error.config?.url?.includes('/change-password');
+// adminApi.interceptors.response.use(
+//     (response) => response,
+//     (error) => {
+//         if (error.response?.status === 401) {
+//             // 비밀번호 변경 API의 경우 자동 리다이렉트 하지 않음
+//             const isPasswordChangeRequest = error.config?.url?.includes('/change-password');
             
-            if (!isPasswordChangeRequest) {
-                // 토큰이 만료되었거나 유효하지 않은 경우
-                alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
-                localStorage.removeItem('adminUser');
-                localStorage.removeItem('adminToken');
-                document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-                window.location.href = '/admin/login';
-            }
-        }
-        return Promise.reject(error);
-    }
-);
+//             if (!isPasswordChangeRequest) {
+//                 // 토큰이 만료되었거나 유효하지 않은 경우
+//                 alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
+//                 localStorage.removeItem('adminUser');
+//                 localStorage.removeItem('adminToken');
+//                 document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+//                 window.location.href = '/admin/login';
+//             }
+//         }
+//         return Promise.reject(error);
+//     }
+// );
 
 // 9090 포트용 API 인스턴스에도 인터셉터 추가
-adminApi9090.interceptors.request.use(
-    (config) => {
-        // 쿠키와 localStorage 둘 다 확인
-        let token = getCookie(ADMIN_TOKEN_COOKIE);
-        if (!token) {
-            token = localStorage.getItem('adminToken');
-        }
+// adminApi9090.interceptors.request.use(
+//     (config) => {
+//         // 쿠키와 localStorage 둘 다 확인
+//         let token = getCookie(ADMIN_TOKEN_COOKIE);
+//         if (!token) {
+//             token = localStorage.getItem('adminToken');
+//         }
 
-        if (token) {
-            config.headers.Authorization = `Bearer ${token}`;
-        }
-        return config;
-    },
-    (error) => {
-        return Promise.reject(error);
-    }
-);
+//         if (token) {
+//             config.headers.Authorization = `Bearer ${token}`;
+//         }
+//         return config;
+//     },
+//     (error) => {
+//         return Promise.reject(error);
+//     }
+// );
 
-adminApi9090.interceptors.response.use(
-    (response) => response,
-    (error) => {
-        if (error.response?.status === 401) {
-            alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
-            localStorage.removeItem('adminUser');
-            localStorage.removeItem('adminToken');
-            document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-            window.location.href = '/admin/login';
-        }
-        return Promise.reject(error);
-    }
-);
+// adminApi9090.interceptors.response.use(
+//     (response) => response,
+//     (error) => {
+//         if (error.response?.status === 401) {
+//             alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
+//             localStorage.removeItem('adminUser');
+//             localStorage.removeItem('adminToken');
+//             document.cookie = `${ADMIN_TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+//             window.location.href = '/admin/login';
+//         }
+//         return Promise.reject(error);
+//     }
+// );
 
 export const adminService = {
     // 관리자 로그인
     login: async (credentials: AdminLoginRequest): Promise<AdminLoginResponse> => {
-        const response = await adminApi.post('/admin/auth/login', credentials);
+        const response = await apiClient.post('/admin/auth/login', credentials);
         return response.data;
     },
 
     // 관리자 정보 조회
     getProfile: async (): Promise<Admin> => {
         try {
-            const response = await adminApi.get('/admin/auth/profile');
+            const response = await apiClient.get('/admin/auth/profile');
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -134,7 +129,7 @@ export const adminService = {
     // 관리자 비밀번호 변경
     changePassword: async (data: AdminChangePasswordRequest): Promise<void> => {
         try {
-            const response = await adminApi.post('/admin/auth/change-password', {
+            const response = await apiClient.post('/admin/auth/change-password', {
                 currentPassword: data.currentPassword,
                 newPassword: data.newPassword,
                 confirmPassword: data.confirmPassword
@@ -163,14 +158,14 @@ export const adminService = {
 
     // 토큰 갱신
     refreshToken: async (refreshToken: string): Promise<{ accessToken: string; refreshToken: string }> => {
-        const response = await adminApi.post('/admin/auth/refresh', { refreshToken });
+        const response = await apiClient.post('/admin/auth/refresh', { refreshToken });
         return response.data;
     },
 
     // 로그아웃
     logout: async (): Promise<void> => {
         try {
-            await adminApi.post('/admin/auth/logout');
+            await apiClient.post('/admin/auth/logout');
         } catch (error) {
             // 로그아웃 요청이 실패해도 클라이언트에서는 로그아웃 처리
         } finally {
@@ -183,7 +178,7 @@ export const adminService = {
 
     // 관리자 목록 조회 (시스템 관리자만 가능)
     getAdmins: async (): Promise<Admin[]> => {
-        const response = await adminApi.get('/admin/auth/admins');
+        const response = await apiClient.get('/admin/auth/admins');
         return response.data;
     },
 
@@ -192,7 +187,7 @@ export const adminService = {
         try {
             // boardType에 따라 엔드포인트 동적 설정
             const endpoint = `/board/${data.boardType}`;
-            const response = await adminApi9090.post(endpoint, data);
+            const response = await apiClient.post(endpoint, data);
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -206,7 +201,7 @@ export const adminService = {
     getNotices: async (boardType: string): Promise<any[]> => {
         try {
             const endpoint = `/board/${boardType}`;
-            const response = await adminApi.get(endpoint);
+            const response = await apiClient.get(endpoint);
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -220,7 +215,7 @@ export const adminService = {
     getNotice: async (boardId: number): Promise<any> => {
         try {
             const endpoint = `/board/${boardId}`;
-            const response = await adminApi9090.get(endpoint);
+            const response = await apiClient.get(endpoint);
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -236,7 +231,7 @@ export const adminService = {
     deleteNotice: async (boardId: number): Promise<void> => {
         try {
             const endpoint = `/board/${boardId}`;
-            const response = await adminApi9090.delete(endpoint);
+            const response = await apiClient.delete(endpoint);
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -264,7 +259,7 @@ export const adminService = {
                 params.sortBy = sortBy;
             }
 
-            const response = await adminApi.get(endpoint, { params });
+            const response = await apiClient.get(endpoint, { params });
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -293,7 +288,7 @@ export const adminService = {
                 requestBody.parentId = parentId;
             }
 
-            const response = await adminApi9090.post(`/board/comment/${boardId}`, requestBody);
+            const response = await apiClient.post(`/board/comment/${boardId}`, requestBody);
             return response.data;
         } catch (error: any) {
             console.error('댓글 작성 에러:', error.response?.data);
@@ -307,7 +302,7 @@ export const adminService = {
     // 게시판 수정 - 9090 포트
     updateBoard: async (boardId: number, data: any): Promise<void> => {
         try {
-            const response = await adminApi9090.put(`/board/${boardId}`, data);
+            const response = await apiClient.put(`/board/${boardId}`, data);
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -320,7 +315,7 @@ export const adminService = {
     // 게시판 삭제 - 9090 포트
     deleteBoard: async (boardId: number): Promise<void> => {
         try {
-            const response = await adminApi9090.delete(`/board/${boardId}`);
+            const response = await apiClient.delete(`/board/${boardId}`);
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -333,7 +328,7 @@ export const adminService = {
     // 댓글 삭제 - 9090 포트
     deleteBoardComment: async (boardId: number, commentId: number): Promise<void> => {
         try {
-            const response = await adminApi9090.delete(`/board/${boardId}/${commentId}`);
+            const response = await apiClient.delete(`/board/${boardId}/${commentId}`);
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -346,7 +341,7 @@ export const adminService = {
     // 댓글 수정 - 9090 포트
     updateBoardComment: async (boardId: number, commentId: number, content: string): Promise<void> => {
         try {
-            const response = await adminApi9090.put(`/board/${boardId}/${commentId}`, { content });
+            const response = await apiClient.put(`/board/${boardId}/${commentId}`, { content });
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -372,7 +367,7 @@ export const adminService = {
             if (reservatedStartDate) params.reservatedStartDate = reservatedStartDate;
             if (reservatedEndDate) params.reservatedEndDate = reservatedEndDate;
 
-            const response = await adminApi.get('/admin/reservations/about-matching', { params });
+            const response = await apiClient.get('/admin/reservations/about-matching', { params });
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -385,7 +380,7 @@ export const adminService = {
     // 수동 매칭 요청
     createManualMatching: async (data: ManualMatchingRequest): Promise<void> => {
         try {
-            const response = await adminApi.post('/admin/matching/manual', data);
+            const response = await apiClient.post('/admin/matching/manual', data);
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -398,7 +393,7 @@ export const adminService = {
     // 매칭 재시도
     retryMatching: async (reservationId: string): Promise<void> => {
         try {
-            const response = await adminApi.post(`/admin/matching/retry/${reservationId}`);
+            const response = await apiClient.post(`/admin/matching/retry/${reservationId}`);
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {
@@ -411,7 +406,7 @@ export const adminService = {
     // 예약 취소
     cancelReservation: async (reservationId: string, data: ReservationCancelRequest): Promise<void> => {
         try {
-            await adminApi.patch(`/admin/reservations/${reservationId}/status`, data);
+            await apiClient.patch(`/admin/reservations/${reservationId}/status`, data);
         } catch (error: any) {
             if (error.response?.status === 401) {
                 throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
@@ -423,7 +418,7 @@ export const adminService = {
     // 예약 상세 정보 조회
     getReservationDetail: async (reservationId: string): Promise<any> => {
         try {
-            const response = await adminApi.get(`/admin/reservations/${reservationId}/detail`);
+            const response = await apiClient.get(`/admin/reservations/${reservationId}/detail`);
             return response.data;
         } catch (error: any) {
             if (error.response?.status === 401) {

--- a/admin/src/lib/apiClient.ts
+++ b/admin/src/lib/apiClient.ts
@@ -1,0 +1,69 @@
+import axios from 'axios';
+import { getCookie, setCookie, ADMIN_TOKEN_COOKIE } from './cookie';
+
+const API_BASE_URL = 'https://api.antmen.site:9093/api/v1';
+
+const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+let isRefreshing = false;
+let failedQueue: any[] = [];
+
+const processQueue = (error: any, token: string | null = null) => {
+  failedQueue.forEach(prom => {
+    if (error) prom.reject(error);
+    else prom.resolve(token);
+  });
+  failedQueue = [];
+};
+
+apiClient.interceptors.request.use(
+  (config) => {
+    let token = getCookie(ADMIN_TOKEN_COOKIE) || localStorage.getItem('adminToken');
+    if (token && config.headers) config.headers.Authorization = `Bearer ${token}`;
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        return new Promise(function(resolve, reject) {
+          failedQueue.push({ resolve, reject });
+        }).then(token => {
+          originalRequest.headers['Authorization'] = 'Bearer ' + token;
+          return apiClient(originalRequest);
+        }).catch(err => Promise.reject(err));
+      }
+      originalRequest._retry = true;
+      isRefreshing = true;
+      const refreshToken = localStorage.getItem('refreshToken');
+      try {
+        const { data } = await axios.post(`${API_BASE_URL}/admin/auth/refresh`, { refreshToken });
+        setCookie(ADMIN_TOKEN_COOKIE, data.accessToken, 1);
+        localStorage.setItem('adminToken', data.accessToken);
+        processQueue(null, data.accessToken);
+        originalRequest.headers['Authorization'] = 'Bearer ' + data.accessToken;
+        return apiClient(originalRequest);
+      } catch (err) {
+        processQueue(err, null);
+        localStorage.removeItem('adminUser');
+        localStorage.removeItem('adminToken');
+        localStorage.removeItem('refreshToken');
+        window.location.href = '/admin/login';
+        return Promise.reject(err);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient; 

--- a/admin/src/pages/admin/StatMatching.tsx
+++ b/admin/src/pages/admin/StatMatching.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../components/ui/card';
-import { fetchAdminMatchingStatistics } from '../../api/adminMatching';
+import { adminMatchingService } from '../../api/adminMatching';
 import { AdminMatchingStatisticsResponseDto } from '../../api/types';
 import { ResponsiveContainer, BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
 
@@ -11,7 +11,7 @@ export const StatMatching: React.FC = () => {
 
   useEffect(() => {
     setLoading(true);
-    fetchAdminMatchingStatistics()
+    adminMatchingService.getMatchingStatistics()
       .then(setData)
       .catch((e) => setError(e.message || '에러 발생'))
       .finally(() => setLoading(false));

--- a/admin/src/pages/admin/StatReservation.tsx
+++ b/admin/src/pages/admin/StatReservation.tsx
@@ -10,7 +10,7 @@ export const StatReservation: React.FC = () => {
 
   useEffect(() => {
     setLoading(true);
-    adminReservationService.getReservationStatistics(7)
+    adminReservationService.getReservationStatistics()
       .then(setData)
       .catch((e) => setError(e.message || '에러 발생'))
       .finally(() => setLoading(false));

--- a/admin/src/pages/admin/StatSatisfaction.tsx
+++ b/admin/src/pages/admin/StatSatisfaction.tsx
@@ -10,7 +10,7 @@ export const StatSatisfaction: React.FC = () => {
 
   useEffect(() => {
     setLoading(true);
-    adminReviewService.getReviewStatistics(3)
+    adminReviewService.getReviewStatistics()
       .then(setData)
       .catch((e) => setError(e.message || '에러 발생'))
       .finally(() => setLoading(false));


### PR DESCRIPTION
- axios 인스턴스 대신 apiClient를 사용하여 API 호출 통합
- 각 API 파일에서 axios 인스턴스 및 관련 인터셉터 코드 제거
- adminMatching, adminCategory, adminCalculation, adminRefunds, adminReservation, adminReview, adminSales, adminService 파일에서 apiClient로의 전환 완료
- 관련 컴포넌트에서 API 호출 방식 변경으로 코드 간소화